### PR TITLE
dra: device allocation observability

### DIFF
--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -60,6 +60,13 @@ type Controller struct {
 	hydrationOnce sync.Once
 }
 
+// ConsumerRef identifies a consumer of a ResourceClaim, typically a pod.
+type ConsumerRef struct {
+	UID       types.UID
+	Name      string
+	Namespace string
+}
+
 // Metadata contains supplementary information about an allocated device, derived from the ReservedFor status of all
 // ResourceClaims that reference it.
 type Metadata struct {
@@ -67,9 +74,9 @@ type Metadata struct {
 	// entirely of pod consumers. A device that is not reserved, or that is reserved by any non-pod consumer, is not
 	// releasable.
 	Releasable bool
-	// PodUIDs is the aggregate set of pod UIDs from the ReservedFor entries of all ResourceClaims that reference the
-	// device. Non-pod consumer UIDs are excluded.
-	PodUIDs []types.UID
+	// Consumers is the aggregate set of pod consumers from the ReservedFor entries of all ResourceClaims that
+	// reference the device. Non-pod consumers are excluded.
+	Consumers []ConsumerRef
 }
 
 func NewController(kubeClient client.Client) *Controller {
@@ -219,7 +226,11 @@ func claimMetadata(claim *resourcev1.ResourceClaim) Metadata {
 	for i := range claim.Status.ReservedFor {
 		ref := &claim.Status.ReservedFor[i]
 		if ref.Resource == string(corev1.ResourcePods) && ref.APIGroup == "" {
-			meta.PodUIDs = append(meta.PodUIDs, ref.UID)
+			meta.Consumers = append(meta.Consumers, ConsumerRef{
+				UID:       ref.UID,
+				Name:      ref.Name,
+				Namespace: claim.Namespace,
+			})
 		} else {
 			meta.Releasable = false
 		}
@@ -236,7 +247,7 @@ func (c *Controller) computeDeviceMetadata(device cloudprovider.DeviceID) Metada
 		if !claimMeta.Releasable {
 			meta.Releasable = false
 		}
-		meta.PodUIDs = append(meta.PodUIDs, claimMeta.PodUIDs...)
+		meta.Consumers = append(meta.Consumers, claimMeta.Consumers...)
 	}
 	return meta
 }

--- a/pkg/controllers/dynamicresources/deviceallocation/debug.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/debug.go
@@ -1,0 +1,173 @@
+package deviceallocation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// DebugState is the top-level debug dump of the controller's internal device allocation state.
+type DebugState struct {
+	Pods   []DebugPod   `json:"pods"`
+	Claims []DebugClaim `json:"claims"`
+	Pools  []DebugPool  `json:"pools"`
+}
+
+// DebugPod represents a pod and the devices allocated to it.
+type DebugPod struct {
+	UID       types.UID `json:"uid"`
+	Namespace string    `json:"namespace"`
+	Name      string    `json:"name"`
+	Devices   []string  `json:"devices"`
+}
+
+// DebugClaim represents a ResourceClaim and the devices allocated to it.
+type DebugClaim struct {
+	Namespace  string          `json:"namespace"`
+	Name       string          `json:"name"`
+	Devices    []string        `json:"devices"`
+	Releasable bool            `json:"releasable"`
+	Consumers  []DebugConsumer `json:"consumers"`
+}
+
+// DebugPool represents a resource pool (driver + pool name) and its devices.
+type DebugPool struct {
+	Driver  string        `json:"driver"`
+	Pool    string        `json:"pool"`
+	Devices []DebugDevice `json:"devices"`
+}
+
+// DebugDevice represents a single device within a pool.
+type DebugDevice struct {
+	Device     string          `json:"device"`
+	Claims     []string        `json:"claims"`
+	Consumers  []DebugConsumer `json:"consumers"`
+	Releasable bool            `json:"releasable"`
+}
+
+// DebugConsumer represents a pod consumer of a device or claim.
+type DebugConsumer struct {
+	UID       types.UID `json:"uid"`
+	Namespace string    `json:"namespace"`
+	Name      string    `json:"name"`
+}
+
+// DebugDump returns a snapshot of the controller's internal state structured for debugging.
+func (c *Controller) DebugDump(ctx context.Context) (*DebugState, error) {
+	select {
+	case <-c.hydrationCh:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	state := &DebugState{}
+
+	// Build pods view: aggregate devices by pod UID
+	type podInfo struct {
+		uid       types.UID
+		namespace string
+		name      string
+		devices   []string
+	}
+	podMap := map[types.UID]*podInfo{}
+	for device, meta := range c.allocatedDevices {
+		deviceStr := device.String()
+		for _, consumer := range meta.Consumers {
+			pi, ok := podMap[consumer.UID]
+			if !ok {
+				pi = &podInfo{uid: consumer.UID, namespace: consumer.Namespace, name: consumer.Name}
+				podMap[consumer.UID] = pi
+			}
+			pi.devices = append(pi.devices, deviceStr)
+		}
+	}
+	for _, pi := range podMap {
+		sort.Strings(pi.devices)
+		state.Pods = append(state.Pods, DebugPod{
+			UID:       pi.uid,
+			Namespace: pi.namespace,
+			Name:      pi.name,
+			Devices:   pi.devices,
+		})
+	}
+	sort.Slice(state.Pods, func(i, j int) bool {
+		if state.Pods[i].Namespace != state.Pods[j].Namespace {
+			return state.Pods[i].Namespace < state.Pods[j].Namespace
+		}
+		return state.Pods[i].Name < state.Pods[j].Name
+	})
+
+	// Build claims view
+	for nn, devices := range c.devicesPerClaim {
+		meta := c.metadataPerClaim[nn]
+		deviceStrs := make([]string, 0, len(devices))
+		for d := range devices {
+			deviceStrs = append(deviceStrs, d.String())
+		}
+		sort.Strings(deviceStrs)
+		consumers := make([]DebugConsumer, len(meta.Consumers))
+		for i, consumer := range meta.Consumers {
+			consumers[i] = DebugConsumer{UID: consumer.UID, Namespace: consumer.Namespace, Name: consumer.Name}
+		}
+		state.Claims = append(state.Claims, DebugClaim{
+			Namespace:  nn.Namespace,
+			Name:       nn.Name,
+			Devices:    deviceStrs,
+			Releasable: meta.Releasable,
+			Consumers:  consumers,
+		})
+	}
+	sort.Slice(state.Claims, func(i, j int) bool {
+		if state.Claims[i].Namespace != state.Claims[j].Namespace {
+			return state.Claims[i].Namespace < state.Claims[j].Namespace
+		}
+		return state.Claims[i].Name < state.Claims[j].Name
+	})
+
+	// Build pools view: group devices by driver/pool
+	type poolKey struct {
+		driver, pool string
+	}
+	poolDevices := map[poolKey][]DebugDevice{}
+	for device, meta := range c.allocatedDevices {
+		pk := poolKey{driver: device.Driver.Value(), pool: device.Pool.Value()}
+		claims := make([]string, 0)
+		if claimSet, ok := c.claimsPerDevice[device]; ok {
+			for nn := range claimSet {
+				claims = append(claims, fmt.Sprintf("%s/%s", nn.Namespace, nn.Name))
+			}
+			sort.Strings(claims)
+		}
+		consumers := make([]DebugConsumer, len(meta.Consumers))
+		for i, consumer := range meta.Consumers {
+			consumers[i] = DebugConsumer{UID: consumer.UID, Namespace: consumer.Namespace, Name: consumer.Name}
+		}
+		poolDevices[pk] = append(poolDevices[pk], DebugDevice{
+			Device:     device.Device.Value(),
+			Claims:     claims,
+			Consumers:  consumers,
+			Releasable: meta.Releasable,
+		})
+	}
+	for pk, devices := range poolDevices {
+		sort.Slice(devices, func(i, j int) bool { return devices[i].Device < devices[j].Device })
+		state.Pools = append(state.Pools, DebugPool{
+			Driver:  pk.driver,
+			Pool:    pk.pool,
+			Devices: devices,
+		})
+	}
+	sort.Slice(state.Pools, func(i, j int) bool {
+		if state.Pools[i].Driver != state.Pools[j].Driver {
+			return state.Pools[i].Driver < state.Pools[j].Driver
+		}
+		return state.Pools[i].Pool < state.Pools[j].Pool
+	})
+
+	return state, nil
+}

--- a/pkg/controllers/dynamicresources/deviceallocation/debug_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/debug_test.go
@@ -1,0 +1,238 @@
+package deviceallocation_test
+
+import (
+	"unique"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	deviceallocation "sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+)
+
+// fullDeviceResult constructs a DeviceRequestAllocationResult with explicit driver and pool.
+func fullDeviceResult(driver, pool, device string) resourcev1.DeviceRequestAllocationResult {
+	return resourcev1.DeviceRequestAllocationResult{
+		Request: "request",
+		Driver:  driver,
+		Pool:    pool,
+		Device:  device,
+	}
+}
+
+// fullResourceClaim constructs a ResourceClaim with explicit driver/pool device results.
+func fullResourceClaim(name string, results ...resourcev1.DeviceRequestAllocationResult) *resourcev1.ResourceClaim {
+	claim := &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{
+				Requests: []resourcev1.DeviceRequest{
+					{
+						Name:    "request",
+						Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: "test-class"},
+					},
+				},
+			},
+		},
+	}
+	if len(results) > 0 {
+		claim.Status.Allocation = &resourcev1.AllocationResult{
+			Devices: resourcev1.DeviceAllocationResult{
+				Results: results,
+			},
+		}
+	}
+	return claim
+}
+
+var _ = Describe("DebugDump", func() {
+	BeforeEach(func() {
+		triggerHydration()
+	})
+
+	It("returns empty slices when no claims exist", func() {
+		state, err := controller.DebugDump(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(state.Pods).To(BeEmpty())
+		Expect(state.Claims).To(BeEmpty())
+		Expect(state.Pools).To(BeEmpty())
+	})
+
+	It("populates all three views for a single claim with a single device reserved for a pod", func() {
+		claim := withReservedFor(
+			resourceClaim("claim-a", deviceResult("device-0")),
+			podRef("pod-a", "uid-a"),
+		)
+		ExpectApplied(ctx, env.Client, claim)
+		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+		state, err := controller.DebugDump(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Pods view
+		Expect(state.Pods).To(HaveLen(1))
+		Expect(state.Pods[0]).To(Equal(deviceallocation.DebugPod{
+			UID:       "uid-a",
+			Namespace: "default",
+			Name:      "pod-a",
+			Devices:   []string{"driver.example.com/pool-a/device-0"},
+		}))
+
+		// Claims view
+		Expect(state.Claims).To(HaveLen(1))
+		Expect(state.Claims[0]).To(Equal(deviceallocation.DebugClaim{
+			Namespace:  "default",
+			Name:       "claim-a",
+			Devices:    []string{"driver.example.com/pool-a/device-0"},
+			Releasable: true,
+			Consumers: []deviceallocation.DebugConsumer{
+				{UID: "uid-a", Namespace: "default", Name: "pod-a"},
+			},
+		}))
+
+		// Pools view
+		Expect(state.Pools).To(HaveLen(1))
+		Expect(state.Pools[0]).To(Equal(deviceallocation.DebugPool{
+			Driver: "driver.example.com",
+			Pool:   "pool-a",
+			Devices: []deviceallocation.DebugDevice{
+				{
+					Device:     "device-0",
+					Claims:     []string{"default/claim-a"},
+					Consumers:  []deviceallocation.DebugConsumer{{UID: "uid-a", Namespace: "default", Name: "pod-a"}},
+					Releasable: true,
+				},
+			},
+		}))
+	})
+
+	It("aggregates devices across multiple claims sharing a device", func() {
+		claimA := withReservedFor(
+			resourceClaim("claim-a", deviceResult("device-0")),
+			podRef("pod-a", "uid-a"),
+		)
+		claimB := withReservedFor(
+			resourceClaim("claim-b", deviceResult("device-0")),
+			podRef("pod-b", "uid-b"),
+		)
+		ExpectApplied(ctx, env.Client, claimA, claimB)
+		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+		state, err := controller.DebugDump(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Both pods should reference the same device
+		Expect(state.Pods).To(HaveLen(2))
+		Expect(state.Pods).To(ContainElement(deviceallocation.DebugPod{
+			UID: "uid-a", Namespace: "default", Name: "pod-a",
+			Devices: []string{"driver.example.com/pool-a/device-0"},
+		}))
+		Expect(state.Pods).To(ContainElement(deviceallocation.DebugPod{
+			UID: "uid-b", Namespace: "default", Name: "pod-b",
+			Devices: []string{"driver.example.com/pool-a/device-0"},
+		}))
+
+		// Two claims
+		Expect(state.Claims).To(HaveLen(2))
+
+		// One pool, one device, two claims
+		Expect(state.Pools).To(HaveLen(1))
+		Expect(state.Pools[0].Devices).To(HaveLen(1))
+		Expect(state.Pools[0].Devices[0].Claims).To(ConsistOf("default/claim-a", "default/claim-b"))
+	})
+
+	It("groups devices by pool across multiple drivers", func() {
+		claimA := withReservedFor(
+			fullResourceClaim("claim-a", fullDeviceResult("driver-1.example.com", "pool-x", "dev-0")),
+			podRef("pod-a", "uid-a"),
+		)
+		claimB := withReservedFor(
+			fullResourceClaim("claim-b", fullDeviceResult("driver-2.example.com", "pool-y", "dev-0")),
+			podRef("pod-b", "uid-b"),
+		)
+		ExpectApplied(ctx, env.Client, claimA, claimB)
+		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+		state, err := controller.DebugDump(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Two pools from different drivers
+		Expect(state.Pools).To(HaveLen(2))
+		// Sorted by driver name
+		Expect(state.Pools[0].Driver).To(Equal("driver-1.example.com"))
+		Expect(state.Pools[1].Driver).To(Equal("driver-2.example.com"))
+	})
+
+	It("shows a claim with no reservation as not releasable with empty consumers", func() {
+		claim := resourceClaim("claim-a", deviceResult("device-0"))
+		ExpectApplied(ctx, env.Client, claim)
+		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+		state, err := controller.DebugDump(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(state.Claims).To(HaveLen(1))
+		Expect(state.Claims[0].Releasable).To(BeFalse())
+		Expect(state.Claims[0].Consumers).To(BeEmpty())
+
+		// No pods since no consumers
+		Expect(state.Pods).To(BeEmpty())
+	})
+
+	It("sorts devices within a pool alphabetically", func() {
+		claim := withReservedFor(
+			resourceClaim("claim-a",
+				deviceResult("device-2"),
+				deviceResult("device-0"),
+				deviceResult("device-1"),
+			),
+			podRef("pod-a", "uid-a"),
+		)
+		ExpectApplied(ctx, env.Client, claim)
+		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+		state, err := controller.DebugDump(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(state.Pools).To(HaveLen(1))
+		Expect(state.Pools[0].Devices).To(HaveLen(3))
+		Expect(state.Pools[0].Devices[0].Device).To(Equal("device-0"))
+		Expect(state.Pools[0].Devices[1].Device).To(Equal("device-1"))
+		Expect(state.Pools[0].Devices[2].Device).To(Equal("device-2"))
+	})
+
+	It("returns consistent device strings across all views", func() {
+		claim := withReservedFor(
+			resourceClaim("claim-a", deviceResult("device-0")),
+			podRef("pod-a", "uid-a"),
+		)
+		ExpectApplied(ctx, env.Client, claim)
+		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claim))
+
+		state, err := controller.DebugDump(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedDevice := cloudprovider.DeviceID{
+			Driver: unique.Make("driver.example.com"),
+			Pool:   unique.Make("pool-a"),
+			Device: unique.Make("device-0"),
+		}.String()
+
+		// Pod view device string matches
+		Expect(state.Pods[0].Devices[0]).To(Equal(expectedDevice))
+		// Claim view device string matches
+		Expect(state.Claims[0].Devices[0]).To(Equal(expectedDevice))
+		// Pool view reconstructed device string matches
+		poolDevice := state.Pools[0].Driver + "/" + state.Pools[0].Pool + "/" + state.Pools[0].Devices[0].Device
+		Expect(poolDevice).To(Equal(expectedDevice))
+	})
+})

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -445,7 +445,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				devices := collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
 					deviceID("device-0"),
-					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
+					deviceallocation.Metadata{Releasable: true, Consumers: []deviceallocation.ConsumerRef{{UID: "uid-a", Name: "pod-a", Namespace: "default"}}},
 				))
 			})
 			It("is true when a claim is reserved for multiple pods", func() {
@@ -462,7 +462,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				devices := collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
 					deviceID("device-0"),
-					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a", "uid-b"}},
+					deviceallocation.Metadata{Releasable: true, Consumers: []deviceallocation.ConsumerRef{{UID: "uid-a", Name: "pod-a", Namespace: "default"}, {UID: "uid-b", Name: "pod-b", Namespace: "default"}}},
 				))
 			})
 			It("is true when two claims sharing a device are both reserved only for pods", func() {
@@ -483,7 +483,10 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				devices := collectDevices(seq)
 				meta := devices[deviceID("device-0")]
 				Expect(meta.Releasable).To(BeTrue())
-				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a"), types.UID("uid-b")))
+				Expect(meta.Consumers).To(ConsistOf(
+				deviceallocation.ConsumerRef{UID: "uid-a", Name: "pod-a", Namespace: "default"},
+				deviceallocation.ConsumerRef{UID: "uid-b", Name: "pod-b", Namespace: "default"},
+			))
 			})
 			// This shouldn't occur since KCM should atomically remove the allocation when it removes the last reservation. If
 			// this does occur, we should be conservative and consider the device allocated.
@@ -513,7 +516,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				devices := collectDevices(seq)
 				meta := devices[deviceID("device-0")]
 				Expect(meta.Releasable).To(BeFalse())
-				Expect(meta.PodUIDs).To(BeNil())
+				Expect(meta.Consumers).To(BeNil())
 			})
 			It("is false when a claim is reserved for a mix of pod and non-pod consumers", func() {
 				claim := withReservedFor(
@@ -529,7 +532,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				devices := collectDevices(seq)
 				meta := devices[deviceID("device-0")]
 				Expect(meta.Releasable).To(BeFalse())
-				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a")))
+				Expect(meta.Consumers).To(ConsistOf(deviceallocation.ConsumerRef{UID: "uid-a", Name: "pod-a", Namespace: "default"}))
 			})
 			It("is false when two claims share a device and one has a non-pod consumer", func() {
 				claimA := withReservedFor(
@@ -549,7 +552,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				devices := collectDevices(seq)
 				meta := devices[deviceID("device-0")]
 				Expect(meta.Releasable).To(BeFalse())
-				Expect(meta.PodUIDs).To(ConsistOf(types.UID("uid-a")))
+				Expect(meta.Consumers).To(ConsistOf(deviceallocation.ConsumerRef{UID: "uid-a", Name: "pod-a", Namespace: "default"}))
 			})
 		})
 
@@ -579,7 +582,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				devices = collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
 					deviceID("device-0"),
-					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
+					deviceallocation.Metadata{Releasable: true, Consumers: []deviceallocation.ConsumerRef{{UID: "uid-a", Name: "pod-a", Namespace: "default"}}},
 				))
 			})
 			It("becomes releasable when the only non-pod claim sharing a device is deleted", func() {
@@ -609,7 +612,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 				devices = collectDevices(seq)
 				Expect(devices).To(HaveKeyWithValue(
 					deviceID("device-0"),
-					deviceallocation.Metadata{Releasable: true, PodUIDs: []types.UID{"uid-a"}},
+					deviceallocation.Metadata{Releasable: true, Consumers: []deviceallocation.ConsumerRef{{UID: "uid-a", Name: "pod-a", Namespace: "default"}}},
 				))
 			})
 		})

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -18,6 +18,7 @@ package operator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -56,6 +57,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/nodeoverlay"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
@@ -97,10 +99,11 @@ func init() {
 type Operator struct {
 	manager.Manager
 
-	KubernetesInterface kubernetes.Interface
-	EventRecorder       events.Recorder
-	Clock               clock.Clock
-	InstanceTypeStore   *nodeoverlay.InstanceTypeStore
+	KubernetesInterface        kubernetes.Interface
+	EventRecorder              events.Recorder
+	Clock                      clock.Clock
+	InstanceTypeStore          *nodeoverlay.InstanceTypeStore
+	DeviceAllocationController *deviceallocation.Controller
 }
 
 type Options struct {
@@ -200,6 +203,10 @@ func NewOperator(o ...option.Function[Options]) (context.Context, *Operator) {
 			EnableWarmup: lo.ToPtr(!options.FromContext(ctx).DisableLeaderElection && !options.FromContext(ctx).DisableControllerWarmup),
 		},
 	}
+	// dacRef holds a reference to the device allocation controller for the debug endpoint handler.
+	// It is set after the manager is created, but before the server starts accepting requests.
+	type dacHolder struct{ c *deviceallocation.Controller }
+	dacRef := &dacHolder{}
 	if options.FromContext(ctx).EnableProfiling {
 		// TODO @joinnis: Investigate the mgrOpts.PprofBindAddress that would allow native support for pprof
 		// On initial look, it seems like this native pprof doesn't support some of the routes that we have here
@@ -215,6 +222,19 @@ func NewOperator(o ...option.Function[Options]) (context.Context, *Operator) {
 			"/debug/pprof/block":        pprof.Handler("block"),
 			"/debug/pprof/goroutine":    pprof.Handler("goroutine"),
 			"/debug/pprof/threadcreate": pprof.Handler("threadcreate"),
+			"/debug/state/deviceallocations": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if dacRef.c == nil {
+					http.Error(w, "device allocation controller not initialized", http.StatusServiceUnavailable)
+					return
+				}
+				state, err := dacRef.c.DebugDump(r.Context())
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(state)
+			}),
 		})
 	}
 	mgr, err := ctrl.NewManager(config, mgrOpts)
@@ -241,13 +261,16 @@ func NewOperator(o ...option.Function[Options]) (context.Context, *Operator) {
 	lo.Must0(mgr.AddHealthzCheck("healthz", healthz.Ping))
 	lo.Must0(mgr.AddReadyzCheck("readyz", healthz.Ping))
 	instanceTypeStore := nodeoverlay.NewInstanceTypeStore()
+	dac := deviceallocation.NewController(mgr.GetClient())
+	dacRef.c = dac
 
 	return ctx, &Operator{
-		Manager:             mgr,
-		KubernetesInterface: kubernetesInterface,
-		EventRecorder:       events.NewRecorder(mgr.GetEventRecorderFor(AppName)),
-		Clock:               clock.RealClock{},
-		InstanceTypeStore:   instanceTypeStore,
+		Manager:                    mgr,
+		KubernetesInterface:        kubernetesInterface,
+		EventRecorder:              events.NewRecorder(mgr.GetEventRecorderFor(AppName)),
+		Clock:                      clock.RealClock{},
+		InstanceTypeStore:          instanceTypeStore,
+		DeviceAllocationController: dac,
 	}
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Provides a new debug endpoint, `/debug/state/deviceallocation` which can be used to query the live deviceallocation state

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
