### PR TITLE
feat: dra integration

### DIFF
--- a/designs/dra-scheduling.md
+++ b/designs/dra-scheduling.md
@@ -80,7 +80,11 @@ Devices come from two sources, prioritized in this order:
 
 Published to the Kubernetes API server as `ResourceSlice` objects by DRA drivers. These represent real, existing devices on nodes in the cluster. In-cluster devices are organized into **pools**, where each pool is identified by a `(driver, poolName)` pair and may span multiple ResourceSlice objects.
 
-In-cluster devices may be **node-local** (accessible only from nodes matching a `NodeSelector`) or **cluster-wide** (accessible from all nodes via `AllNodes: true`). Node-local devices carry topology requirements that constrain which nodes can use them.
+In-cluster devices may be **node-local** or **cluster-wide** (accessible from all nodes via `AllNodes: true`). Node-local devices come in two forms:
+- **`NodeName`-pinned**: the slice sets `spec.nodeName` to a single node. These devices are accessible only from that exact node, so they can satisfy an existing node whose node name matches but can never satisfy an in-flight NodeClaim (which has no concrete node yet). They carry no label topology requirement — the node identity itself is the constraint.
+- **`NodeSelector`-scoped**: the slice uses a label `NodeSelector`. These carry topology requirements that constrain which nodes can use them, and may match both existing nodes and in-flight NodeClaims whose requirements are compatible.
+
+`ResourceSlice` objects owned by **uninitialized nodes** (nodes that have not yet reached the `Initialized` status condition) are excluded from pools. Until a node is initialized, its devices are represented by template devices instead, so its published slices are not counted as in-cluster devices (see [NodeClaim Abstraction](#nodeclaim-abstraction) and [Scheduler Initialization](#scheduler-initialization)).
 
 ### Template Devices
 
@@ -118,12 +122,12 @@ A claim with no allocation — neither in-cluster nor in-memory — proceeds thr
 
 ### Pool Gathering
 
-Pools are built from in-cluster `ResourceSlice` objects published to the API server. The gathering process:
+Pools are built from in-cluster `ResourceSlice` objects published to the API server. The provided slice set is pre-filtered by the caller to exclude slices owned by deleting/excluded nodes and by uninitialized nodes (see [Scheduler Initialization](#scheduler-initialization)); because *all* of an uninitialized node's slices are excluded, that node is wholly represented by template devices and never contributes a partial pool. The gathering process:
 
 1. Groups slices by `(driver, poolName)`.
 2. Tracks the highest generation per pool. When a newer generation is encountered, all previously accumulated slices for that pool are discarded.
 3. Determines **completeness** by comparing the total slice count at the current generation against the pool's declared `ResourceSliceCount`. Completeness is a global property computed across all slices (matching and non-matching).
-4. Filters slices by node affinity compatibility with the NodeClaim's requirements. Only matching slices contribute devices; non-matching slices still participate in generation tracking and completeness checks.
+4. Filters slices by node affinity accessibility to the NodeClaim. A slice's devices are accessible when the slice is `AllNodes`, when it pins itself via `spec.nodeName` and that name equals the NodeClaim's node (existing nodes only — in-flight NodeClaims have no node name and never match a `NodeName`-pinned slice), or when its label `NodeSelector` is compatible with the NodeClaim's requirements. Only accessible slices contribute devices; inaccessible slices still participate in generation tracking and completeness checks.
 5. Detects **invalid** pools with duplicate device names across slices.
 
 For in-flight NodeClaims, a pool is included if it is compatible with *any* remaining candidate instance type.
@@ -410,8 +414,9 @@ type Allocator struct {
 
     // The pre-filtered set of in-cluster ResourceSlices, provided at construction
     // time. The caller is responsible for excluding slices from deleting/excluded
-    // nodes before passing them in. The allocator treats this as the complete
-    // universe of in-cluster slices and does not query cluster state directly.
+    // nodes and from uninitialized nodes before passing them in. The allocator
+    // treats this as the complete universe of in-cluster slices and does not query
+    // cluster state directly.
     // Uses the ResourceSlice interface to abstract over API server slices.
     inClusterSlices []ResourceSlice
 
@@ -530,7 +535,7 @@ When the scheduler prunes an instance type from a NodeClaim's candidate set, `Re
 
 At scheduler construction (`NewScheduler`), build the DRA allocator:
 
-1. **Collect and filter in-cluster ResourceSlices**: Gather all `ResourceSlice` objects from the cluster. Filter out slices owned by nodes that are not in the stateNode set passed to the scheduler (i.e., deleting nodes, disruption candidates). Non-node-owned slices (no node owner reference) are always included. This filtering uses `metadata.ownerReferences` to determine node ownership — `spec.nodeName` indicates accessibility, not ownership.
+1. **Collect and filter in-cluster ResourceSlices**: Gather all `ResourceSlice` objects from the cluster. Filter out slices owned by nodes that are not in the stateNode set passed to the scheduler (i.e., deleting nodes, disruption candidates). Also filter out slices owned by **uninitialized nodes** (nodes that have not reached the `Initialized` status condition) — an uninitialized node's devices are represented by template devices, so including its published slices would double-count them. Non-node-owned slices (no node owner reference) are always included. This filtering uses `metadata.ownerReferences` to determine node ownership — `spec.nodeName` indicates accessibility, not ownership.
 2. Obtain the set of allocated devices from the `deviceallocation` controller's tracking state, filtered for deleting pods. The `deviceallocation.Controller` is injected directly into the provisioner (not accessed through an interface). Devices with no consumers (unowned) are treated as releasable. Deleting pods should include all pods on deleting nodes and disruption candidates.
 3. Build `AttributeBindings` from instance type metadata grouped by NodePool.
 4. Construct the `Allocator` via `NewAllocator(inClusterSlices, allocatedDevices, attributeBindings, kubeClient)`. The `allocationTracker`, `poolCache`, and `claimAllocationMetadata` start empty and are populated via `Commit()` during the scheduling loop.
@@ -542,7 +547,7 @@ The allocator is stored on the `Scheduler` struct and passed through to NodeClai
 The allocator operates on a `NodeClaim` interface that abstracts over three lifecycle phases:
 
 - **Existing initialized nodes.** Have a single known instance type. `ResourceSlices()` returns empty (all devices are already published in-cluster).
-- **Pre-initialized nodes.** Have a single known instance type but outstanding template devices not yet published. `ResourceSlices()` returns templates under that instance type.
+- **Pre-initialized nodes.** Have a single known instance type but have not yet reached the `Initialized` status condition. Template devices are the source of truth until initialization completes: `ResourceSlices()` returns the instance type's **full** template set under that instance type, and the node's published in-cluster slices are excluded from pool gathering.
 - **In-flight NodeClaims.** Have multiple candidate instance types. `ResourceSlices()` returns templates for all candidates.
 
 This abstraction allows the allocator to use identical logic regardless of whether it is evaluating an existing node, a node being set up, or a node that does not yet exist.
@@ -558,10 +563,10 @@ For existing (initialized) nodes:
 4. If allocation succeeds, the pod can be placed. The `AllocationResult.Allocation` is held until `Add()` is called. **Note**: `AllocationResult.Requirements` are **not** merged into the existing node's requirements — existing node requirements are immutable (already set in stone). The allocator validates compatibility internally; if claims could not be satisfied with the node's requirements, the allocation would have failed.
 5. On `Add()`, call `AllocationResult.Allocation.Commit(ctx)` to mark the devices as consumed.
 
-For pre-initialized nodes (existing but not yet fully initialized):
-1. The NodeClaim wraps a real node with a known instance type, but some drivers have not yet published complete pools.
-2. Published slices for registered drivers are already in the in-cluster pool set.
-3. `NodeClaim.ResourceSlices()` returns only the **outstanding** in-memory templates — i.e., templates for drivers that have not yet published a complete pool. These appear under the single known instance type in the map.
+For pre-initialized nodes (existing but not yet at the `Initialized` status condition):
+1. The NodeClaim wraps a real node with a known instance type that has not yet reached the `Initialized` status condition.
+2. Template devices are the source of truth until the node is initialized. `NodeClaim.ResourceSlices()` returns the instance type's **full** in-memory template set under the single known instance type.
+3. The node's published in-cluster `ResourceSlice`s are excluded from pool gathering while it is uninitialized (see [Scheduler Initialization](#scheduler-initialization)), so devices are not double-counted across templates and published slices. Once the node becomes initialized, its published slices become authoritative and `ResourceSlices()` returns empty — the existing initialized-node behavior.
 
 ### In-Flight NodeClaim Evaluation
 

--- a/designs/dra-scheduling.md
+++ b/designs/dra-scheduling.md
@@ -104,6 +104,8 @@ Claims are processed sequentially. The allocator maintains **effective requireme
 
 A claim that already has `status.allocation` set on the API server is fully allocated in the cluster. The allocator reads the topology requirements from `status.allocation.nodeSelector` and checks them for compatibility with the current effective requirements. If incompatible, the allocation fails immediately. If compatible, the requirements are merged into the effective requirements — tightening the baseline for subsequent claims and for pool gathering/filtering — and are included in the `AllocationResult`. No device reservation or DFS is needed for this claim; its devices are already committed.
 
+**Exception — claims held by deleting pods.** When a claim's `status.allocation` is set but its `status.reservedFor` consists *entirely* of pods that are being deleted (pods on deleting nodes, disruption candidates, or individually-deleting pods — the same set used to free devices during allocator initialization), the claim is reclassified as **Unallocated** and re-run through the DFS. The device it currently holds has already been freed from the allocated-device seed set for the same reason, so the DFS re-allocates the claim onto the replacement capacity rather than treating it as committed in place. A claim reserved by a mix of deleting and live pods — or by any non-pod consumer — remains committed in place, preserving the live consumers' device and the topology it contributes (this is also what keeps a partially-consumed multi-allocatable device pinned for its surviving consumers).
+
 ### Allocated (In-Memory)
 
 Multiple pending pods may reference the same ResourceClaim. When a claim that was not previously allocated is first allocated during the scheduling loop, the allocator records per-claim metadata: the associated NodeClaim ID, whether template devices were used, and the accumulated topology requirements. When a subsequent pod references that same claim, the allocator uses this metadata instead of re-running the DFS:
@@ -627,3 +629,15 @@ The gate runs in `Initialization.Reconcile()` immediately after the extended-res
 **Re-reconciliation**: the lifecycle controller watches `ResourceSlice` objects — but only when DRA is enabled — mapping a slice to the NodeClaim(s) backing the node the slice is local to (via `spec.nodeName`/Node owner reference → provider ID). This drives prompt re-evaluation as drivers publish their pools.
 
 **RBAC**: operating the gate requires the Karpenter controller to have `get;list;watch` on `resource.k8s.io` `resourceslices`. Distributions enabling DRA must grant this (the provisioning path already lists slices; this adds the `watch` verb).
+
+### Disruption / Consolidation Re-allocation Semantics
+
+Consolidation (and drift) reuse the scheduler directly via `disruption.SimulateScheduling`, so DRA is inherited. Two behaviors keep the simulation correct:
+
+1. **Candidate slices are excluded from the device universe.** `SimulateScheduling` removes consolidation candidate nodes from the `stateNodes` passed to `NewScheduler`. Because pool gathering only includes published `ResourceSlice`s owned by initialized nodes in `stateNodes` (see [Scheduler Initialization](#scheduler-initialization)), a candidate node's devices are not considered scheduling targets — the simulation can't "keep" a pod on a node it is proposing to remove.
+
+2. **Candidate pods' devices are freed and their claims re-allocated.** The set of deleting pods used during allocator construction includes not only pods on already-deleting nodes but also the **disruption candidate pods** being rescheduled (the PDB-reschedulable pods on candidate nodes). This drives a *dual mechanism* that must stay consistent:
+   - **Device freeing**: a device allocated exclusively to deleting pods is removed from the allocated-device seed set (`gatherAllocatedDevices`), and a multi-allocatable device has the deleting pods' share of its consumed capacity subtracted.
+   - **Claim re-allocation**: a claim reserved entirely by deleting pods is reclassified from "Allocated (In-Cluster)" to Unallocated and re-run through the DFS (see [Allocated (In-Cluster)](#allocated-in-cluster)).
+
+   Both halves are driven by the *same* deleting-pod set and the same per-claim `reservedFor` pod accounting, so a freed device is always matched by a re-allocated claim (and vice versa). A device or claim shared with a live pod is neither freed nor reclassified, so live consumers are never disturbed.

--- a/designs/dra-scheduling.md
+++ b/designs/dra-scheduling.md
@@ -608,7 +608,7 @@ Both of these happen inside `NodeClaim.Add()`, after the existing resource and t
 When the scheduling loop completes and NodeClaims are finalized:
 
 1. Collect the set of DRA driver names from all ResourceClaims of pods scheduled to the NodeClaim.
-2. Set the `karpenter.sh/dra-drivers` annotation on the NodeClaim (per the lifecycle doc).
+2. Set the `karpenter.sh/requested-dra-drivers` annotation on the NodeClaim (per the lifecycle doc).
 3. The finalized NodeClaim carries both the standard resource requests and the DRA driver annotation for the initialization controller to gate on.
 
 ### NodeClaim Initialization Gating
@@ -619,12 +619,12 @@ A node's DRA devices are only usable once its DRA drivers have published their `
 
 The gate runs in `Initialization.Reconcile()` immediately after the extended-resource registration check (`RequestedResourcesRegistered`) and before the node is labeled initialized. Its semantics:
 
-- **Expected drivers** come from the NodeClaim's `karpenter.sh/dra-drivers` annotation (the comma-separated set populated at finalization, above).
+- **Expected drivers** come from the NodeClaim's `karpenter.sh/requested-dra-drivers` annotation (the comma-separated set populated at finalization, above).
 - **Publication criterion**: a driver is satisfied once it has published **at least one complete pool** among the node's `ResourceSlice`s. A pool is complete when the number of observed slices at the pool's highest generation equals the slices' declared `ResourceSliceCount`. This mirrors the allocator's pool-completeness notion (`Pool.Incomplete`, see [Pool Gathering](#pool-gathering)) but is reimplemented standalone in the lifecycle controller so it does not take on the scheduling package's dependencies.
 - **Node-local slices**: only slices local to the node are considered — those pinned via `spec.nodeName` or carrying a `Kind=Node` owner reference naming the node. Cluster-wide (`AllNodes`) slices are not node-owned and do not contribute to the gate.
 - If any expected driver lacks a complete pool, the controller sets `Initialized` to `Unknown` with reason `DRADriverPoolsNotPublished` and requeues. Once every expected driver has a complete pool, initialization proceeds.
 
-**No-op fallback**: a NodeClaim with no `karpenter.sh/dra-drivers` annotation (non-DRA nodes) skips the gate entirely. The whole check is additionally guarded on DRA being enabled (`--ignore-dra-requests=false`), so DRA-disabled clusters never list `ResourceSlice`s.
+**No-op fallback**: a NodeClaim with no `karpenter.sh/requested-dra-drivers` annotation (non-DRA nodes) skips the gate entirely. The whole check is additionally guarded on DRA being enabled (`--ignore-dra-requests=false`), so DRA-disabled clusters never list `ResourceSlice`s.
 
 **Re-reconciliation**: the lifecycle controller watches `ResourceSlice` objects — but only when DRA is enabled — mapping a slice to the NodeClaim(s) backing the node the slice is local to (via `spec.nodeName`/Node owner reference → provider ID). This drives prompt re-evaluation as drivers publish their pools.
 

--- a/designs/dra-scheduling.md
+++ b/designs/dra-scheduling.md
@@ -608,3 +608,22 @@ When the scheduling loop completes and NodeClaims are finalized:
 1. Collect the set of DRA driver names from all ResourceClaims of pods scheduled to the NodeClaim.
 2. Set the `karpenter.sh/dra-drivers` annotation on the NodeClaim (per the lifecycle doc).
 3. The finalized NodeClaim carries both the standard resource requests and the DRA driver annotation for the initialization controller to gate on.
+
+### NodeClaim Initialization Gating
+
+**File**: `pkg/controllers/nodeclaim/lifecycle/initialization.go`
+
+A node's DRA devices are only usable once its DRA drivers have published their `ResourceSlice` pools to the API server. To avoid marking a node ready before its allocated devices can actually bind, the initialization controller gates the `Initialized` status condition on driver publication.
+
+The gate runs in `Initialization.Reconcile()` immediately after the extended-resource registration check (`RequestedResourcesRegistered`) and before the node is labeled initialized. Its semantics:
+
+- **Expected drivers** come from the NodeClaim's `karpenter.sh/dra-drivers` annotation (the comma-separated set populated at finalization, above).
+- **Publication criterion**: a driver is satisfied once it has published **at least one complete pool** among the node's `ResourceSlice`s. A pool is complete when the number of observed slices at the pool's highest generation equals the slices' declared `ResourceSliceCount`. This mirrors the allocator's pool-completeness notion (`Pool.Incomplete`, see [Pool Gathering](#pool-gathering)) but is reimplemented standalone in the lifecycle controller so it does not take on the scheduling package's dependencies.
+- **Node-local slices**: only slices local to the node are considered — those pinned via `spec.nodeName` or carrying a `Kind=Node` owner reference naming the node. Cluster-wide (`AllNodes`) slices are not node-owned and do not contribute to the gate.
+- If any expected driver lacks a complete pool, the controller sets `Initialized` to `Unknown` with reason `DRADriverPoolsNotPublished` and requeues. Once every expected driver has a complete pool, initialization proceeds.
+
+**No-op fallback**: a NodeClaim with no `karpenter.sh/dra-drivers` annotation (non-DRA nodes) skips the gate entirely. The whole check is additionally guarded on DRA being enabled (`--ignore-dra-requests=false`), so DRA-disabled clusters never list `ResourceSlice`s.
+
+**Re-reconciliation**: the lifecycle controller watches `ResourceSlice` objects — but only when DRA is enabled — mapping a slice to the NodeClaim(s) backing the node the slice is local to (via `spec.nodeName`/Node owner reference → provider ID). This drives prompt re-evaluation as drivers publish their pools.
+
+**RBAC**: operating the gate requires the Karpenter controller to have `get;list;watch` on `resource.k8s.io` `resourceslices`. Distributions enabling DRA must grant this (the provisioning path already lists slices; this adds the `watch` verb).

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -53,6 +53,10 @@ const (
 	NodePoolHashVersionAnnotationKey           = apis.Group + "/nodepool-hash-version"
 	NodeClaimTerminationTimestampAnnotationKey = apis.Group + "/nodeclaim-termination-timestamp"
 	NodeClaimMinValuesRelaxedAnnotationKey     = apis.Group + "/nodeclaim-min-values-relaxed"
+	// DRADriversAnnotationKey records the comma-separated set of DRA driver names whose devices were allocated to pods
+	// scheduled to this NodeClaim. The initialization controller can gate on these drivers having published their
+	// ResourceSlices before marking the node initialized.
+	DRADriversAnnotationKey = apis.Group + "/dra-drivers"
 )
 
 // Karpenter specific finalizers

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -56,7 +56,7 @@ const (
 	// DRADriversAnnotationKey records the comma-separated set of DRA driver names whose devices were allocated to pods
 	// scheduled to this NodeClaim. The initialization controller can gate on these drivers having published their
 	// ResourceSlices before marking the node initialized.
-	DRADriversAnnotationKey = apis.Group + "/dra-drivers"
+	DRADriversAnnotationKey = apis.Group + "/requested-dra-drivers"
 )
 
 // Karpenter specific finalizers

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -232,42 +231,36 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, np *v1.NodePool) ([]
 		return c.InstanceTypes, nil
 	}
 	return []*cloudprovider.InstanceType{
-		NewInstanceType(InstanceTypeOptions{
-			Name: "default-instance-type",
-		}),
-		NewInstanceType(InstanceTypeOptions{
-			Name: "small-instance-type",
-			Resources: map[corev1.ResourceName]resource.Quantity{
+		NewInstanceType("default-instance-type"),
+		NewInstanceType("small-instance-type",
+			WithResources(corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
-			},
-		}),
-		NewInstanceType(InstanceTypeOptions{
-			Name: "gpu-vendor-instance-type",
-			Resources: map[corev1.ResourceName]resource.Quantity{
+			}),
+		),
+		NewInstanceType("gpu-vendor-instance-type",
+			WithResources(corev1.ResourceList{
 				ResourceGPUVendorA: resource.MustParse("2"),
-			}}),
-		NewInstanceType(InstanceTypeOptions{
-			Name: "gpu-vendor-b-instance-type",
-			Resources: map[corev1.ResourceName]resource.Quantity{
+			}),
+		),
+		NewInstanceType("gpu-vendor-b-instance-type",
+			WithResources(corev1.ResourceList{
 				ResourceGPUVendorB: resource.MustParse("2"),
-			},
-		}),
-		NewInstanceType(InstanceTypeOptions{
-			Name:             "arm-instance-type",
-			Architecture:     "arm64",
-			OperatingSystems: sets.New("ios", string(corev1.Linux), string(corev1.Windows), "darwin"),
-			Resources: map[corev1.ResourceName]resource.Quantity{
+			}),
+		),
+		NewInstanceType("arm-instance-type",
+			WithArchitecture("arm64"),
+			WithOperatingSystems("ios", string(corev1.Linux), string(corev1.Windows), "darwin"),
+			WithResources(corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("16"),
 				corev1.ResourceMemory: resource.MustParse("128Gi"),
-			},
-		}),
-		NewInstanceType(InstanceTypeOptions{
-			Name: "single-pod-instance-type",
-			Resources: map[corev1.ResourceName]resource.Quantity{
+			}),
+		),
+		NewInstanceType("single-pod-instance-type",
+			WithResources(corev1.ResourceList{
 				corev1.ResourcePods: resource.MustParse("1"),
-			},
-		}),
+			}),
+		),
 	}, nil
 }
 

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -19,9 +19,12 @@ package fake
 import (
 	"fmt"
 	"strings"
+	"unique"
 
+	"github.com/awslabs/operatorpkg/option"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -46,32 +49,75 @@ func init() {
 	)
 }
 
-func NewInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
-	return NewInstanceTypeWithCustomRequirement(options, nil)
+type InstanceTypeOptions = option.Function[InstanceTypeConfig]
+
+type InstanceTypeConfig struct {
+	Resources              corev1.ResourceList
+	Offerings              cloudprovider.Offerings
+	Architecture           string
+	OperatingSystems       sets.Set[string]
+	ResourceSliceTemplates []*cloudprovider.ResourceSliceTemplate
+	AttributeBindings      []*cloudprovider.AttributeBinding
+	Requirements           []*scheduling.Requirement
 }
 
-func NewInstanceTypeWithCustomRequirement(options InstanceTypeOptions, customReq *scheduling.Requirement) *cloudprovider.InstanceType {
-	if options.Resources == nil {
-		options.Resources = map[corev1.ResourceName]resource.Quantity{}
+func WithResources(resources corev1.ResourceList) InstanceTypeOptions {
+	return func(c *InstanceTypeConfig) { c.Resources = resources }
+}
+
+func WithOfferings(offerings ...cloudprovider.Offering) InstanceTypeOptions {
+	return func(c *InstanceTypeConfig) {
+		c.Offerings = lo.ToSlicePtr(offerings)
 	}
-	if r := options.Resources[corev1.ResourceCPU]; r.IsZero() {
-		options.Resources[corev1.ResourceCPU] = resource.MustParse("4")
+}
+
+func WithArchitecture(arch string) InstanceTypeOptions {
+	return func(c *InstanceTypeConfig) { c.Architecture = arch }
+}
+
+func WithOperatingSystems(os ...string) InstanceTypeOptions {
+	return func(c *InstanceTypeConfig) { c.OperatingSystems = sets.New(os...) }
+}
+
+func WithResourceSliceTemplates(templates ...cloudprovider.ResourceSliceTemplate) InstanceTypeOptions {
+	return func(c *InstanceTypeConfig) {
+		c.ResourceSliceTemplates = lo.ToSlicePtr(templates)
 	}
-	if r := options.Resources[corev1.ResourceMemory]; r.IsZero() {
-		options.Resources[corev1.ResourceMemory] = resource.MustParse("4Gi")
+}
+
+func WithAttributeBindings(bindings ...cloudprovider.AttributeBinding) InstanceTypeOptions {
+	return func(c *InstanceTypeConfig) {
+		c.AttributeBindings = lo.ToSlicePtr(bindings)
 	}
-	if r := options.Resources[corev1.ResourcePods]; r.IsZero() {
-		options.Resources[corev1.ResourcePods] = resource.MustParse("5")
+}
+
+func WithRequirements(reqs ...*scheduling.Requirement) InstanceTypeOptions {
+	return func(c *InstanceTypeConfig) { c.Requirements = reqs }
+}
+
+func NewInstanceType(name string, opts ...InstanceTypeOptions) *cloudprovider.InstanceType {
+	cfg := option.Resolve(opts...)
+	if cfg.Resources == nil {
+		cfg.Resources = corev1.ResourceList{}
 	}
-	if len(options.Offerings) == 0 {
-		options.Offerings = []*cloudprovider.Offering{
+	if r := cfg.Resources[corev1.ResourceCPU]; r.IsZero() {
+		cfg.Resources[corev1.ResourceCPU] = resource.MustParse("4")
+	}
+	if r := cfg.Resources[corev1.ResourceMemory]; r.IsZero() {
+		cfg.Resources[corev1.ResourceMemory] = resource.MustParse("4Gi")
+	}
+	if r := cfg.Resources[corev1.ResourcePods]; r.IsZero() {
+		cfg.Resources[corev1.ResourcePods] = resource.MustParse("5")
+	}
+	if len(cfg.Offerings) == 0 {
+		cfg.Offerings = cloudprovider.Offerings{
 			{
 				Available: true,
 				Requirements: scheduling.NewLabelRequirements(map[string]string{
 					v1.CapacityTypeLabelKey:  "spot",
 					corev1.LabelTopologyZone: "test-zone-1",
 				}),
-				Price: PriceFromResources(options.Resources),
+				Price: PriceFromResources(cfg.Resources),
 			},
 			{
 				Available: true,
@@ -79,7 +125,7 @@ func NewInstanceTypeWithCustomRequirement(options InstanceTypeOptions, customReq
 					v1.CapacityTypeLabelKey:  "spot",
 					corev1.LabelTopologyZone: "test-zone-2",
 				}),
-				Price: PriceFromResources(options.Resources),
+				Price: PriceFromResources(cfg.Resources),
 			},
 			{
 				Available: true,
@@ -87,7 +133,7 @@ func NewInstanceTypeWithCustomRequirement(options InstanceTypeOptions, customReq
 					v1.CapacityTypeLabelKey:  "on-demand",
 					corev1.LabelTopologyZone: "test-zone-1",
 				}),
-				Price: PriceFromResources(options.Resources),
+				Price: PriceFromResources(cfg.Resources),
 			},
 			{
 				Available: true,
@@ -95,7 +141,7 @@ func NewInstanceTypeWithCustomRequirement(options InstanceTypeOptions, customReq
 					v1.CapacityTypeLabelKey:  "on-demand",
 					corev1.LabelTopologyZone: "test-zone-2",
 				}),
-				Price: PriceFromResources(options.Resources),
+				Price: PriceFromResources(cfg.Resources),
 			},
 			{
 				Available: true,
@@ -103,35 +149,35 @@ func NewInstanceTypeWithCustomRequirement(options InstanceTypeOptions, customReq
 					v1.CapacityTypeLabelKey:  "on-demand",
 					corev1.LabelTopologyZone: "test-zone-3",
 				}),
-				Price: PriceFromResources(options.Resources),
+				Price: PriceFromResources(cfg.Resources),
 			},
 		}
 	}
-	if len(options.Architecture) == 0 {
-		options.Architecture = "amd64"
+	if len(cfg.Architecture) == 0 {
+		cfg.Architecture = "amd64"
 	}
-	if options.OperatingSystems.Len() == 0 {
-		options.OperatingSystems = sets.New(string(corev1.Linux), string(corev1.Windows), "darwin")
+	if cfg.OperatingSystems.Len() == 0 {
+		cfg.OperatingSystems = sets.New(string(corev1.Linux), string(corev1.Windows), "darwin")
 	}
 	requirements := scheduling.NewRequirements(
-		scheduling.NewRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, options.Name),
-		scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, options.Architecture),
-		scheduling.NewRequirement(corev1.LabelOSStable, corev1.NodeSelectorOpIn, sets.List(options.OperatingSystems)...),
-		scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, lo.Map(options.Offerings.Available(), func(o *cloudprovider.Offering, _ int) string {
+		scheduling.NewRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, name),
+		scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, cfg.Architecture),
+		scheduling.NewRequirement(corev1.LabelOSStable, corev1.NodeSelectorOpIn, sets.List(cfg.OperatingSystems)...),
+		scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, lo.Map(cfg.Offerings.Available(), func(o *cloudprovider.Offering, _ int) string {
 			return o.Requirements.Get(corev1.LabelTopologyZone).Any()
 		})...),
-		scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, lo.Map(options.Offerings.Available(), func(o *cloudprovider.Offering, _ int) string {
+		scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, lo.Map(cfg.Offerings.Available(), func(o *cloudprovider.Offering, _ int) string {
 			return o.Requirements.Get(v1.CapacityTypeLabelKey).Any()
 		})...),
 		scheduling.NewRequirement(LabelInstanceSize, corev1.NodeSelectorOpDoesNotExist),
 		scheduling.NewRequirement(ExoticInstanceLabelKey, corev1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(IntegerInstanceLabelKey, corev1.NodeSelectorOpIn, fmt.Sprint(options.Resources.Cpu().Value())),
+		scheduling.NewRequirement(IntegerInstanceLabelKey, corev1.NodeSelectorOpIn, fmt.Sprint(cfg.Resources.Cpu().Value())),
 	)
-	if customReq != nil {
-		requirements.Add(customReq)
+	for _, req := range cfg.Requirements {
+		requirements.Add(req)
 	}
-	if options.Resources.Cpu().Cmp(resource.MustParse("4")) > 0 &&
-		options.Resources.Memory().Cmp(resource.MustParse("8Gi")) > 0 {
+	if cfg.Resources.Cpu().Cmp(resource.MustParse("4")) > 0 &&
+		cfg.Resources.Memory().Cmp(resource.MustParse("8Gi")) > 0 {
 		requirements.Get(LabelInstanceSize).Insert("large")
 		requirements.Get(ExoticInstanceLabelKey).Insert("optional")
 	} else {
@@ -139,10 +185,14 @@ func NewInstanceTypeWithCustomRequirement(options InstanceTypeOptions, customReq
 	}
 
 	return &cloudprovider.InstanceType{
-		Name:         options.Name,
+		Name:         name,
 		Requirements: requirements,
-		Offerings:    options.Offerings,
-		Capacity:     options.Resources,
+		Offerings:    cfg.Offerings,
+		Capacity:     cfg.Resources,
+		DynamicResources: cloudprovider.DynamicResources{
+			ResourceSliceTemplates: cfg.ResourceSliceTemplates,
+			AttributeBindings:      cfg.AttributeBindings,
+		},
 		Overhead: &cloudprovider.InstanceTypeOverhead{
 			KubeReserved: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -150,6 +200,31 @@ func NewInstanceTypeWithCustomRequirement(options InstanceTypeOptions, customReq
 			},
 		},
 	}
+}
+
+// ResourceSliceTemplate builds a cloud provider ResourceSliceTemplate with the given driver, pool, and devices.
+// It is a convenience for tests constructing instance types with DRA device shapes via WithResourceSliceTemplates.
+func ResourceSliceTemplate(driver, pool string, devices ...cloudprovider.Device) cloudprovider.ResourceSliceTemplate {
+	return cloudprovider.ResourceSliceTemplate{
+		Driver:  unique.Make(driver),
+		Pool:    cloudprovider.ResourcePool{Name: unique.Make(pool)},
+		Devices: devices,
+	}
+}
+
+// Device builds a cloud provider DRA device with the given name and optional attributes.
+func Device(name string, attributes map[resourcev1.QualifiedName]resourcev1.DeviceAttribute) cloudprovider.Device {
+	return cloudprovider.Device{
+		Name:       unique.Make(name),
+		Attributes: attributes,
+	}
+}
+
+// Devices builds a slice of attribute-less DRA devices from the given names.
+func Devices(names ...string) []cloudprovider.Device {
+	return lo.Map(names, func(name string, _ int) cloudprovider.Device {
+		return Device(name, nil)
+	})
 }
 
 // InstanceTypesAssorted create many unique instance types with varying CPU/memory/architecture/OS/zone/capacity type.
@@ -161,27 +236,25 @@ func InstanceTypesAssorted() []*cloudprovider.InstanceType {
 				for _, ct := range []string{v1.CapacityTypeSpot, v1.CapacityTypeOnDemand} {
 					for _, os := range []sets.Set[string]{sets.New(string(corev1.Linux)), sets.New(string(corev1.Windows))} {
 						for _, arch := range []string{v1.ArchitectureAmd64, v1.ArchitectureArm64} {
-							opts := InstanceTypeOptions{
-								Name:             fmt.Sprintf("%d-cpu-%d-mem-%s-%s-%s-%s", cpu, mem, arch, strings.Join(sets.List(os), ","), zone, ct),
-								Architecture:     arch,
-								OperatingSystems: os,
-								Resources: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", cpu)),
-									corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", mem)),
-								},
+							resources := corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", cpu)),
+								corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", mem)),
 							}
-							price := PriceFromResources(opts.Resources)
-							opts.Offerings = []*cloudprovider.Offering{
-								{
+							price := PriceFromResources(resources)
+							instanceTypes = append(instanceTypes, NewInstanceType(
+								fmt.Sprintf("%d-cpu-%d-mem-%s-%s-%s-%s", cpu, mem, arch, strings.Join(sets.List(os), ","), zone, ct),
+								WithArchitecture(arch),
+								WithOperatingSystems(sets.List(os)...),
+								WithResources(resources),
+								WithOfferings(cloudprovider.Offering{
 									Available: true,
 									Requirements: scheduling.NewLabelRequirements(map[string]string{
 										v1.CapacityTypeLabelKey:  ct,
 										corev1.LabelTopologyZone: zone,
 									}),
 									Price: price,
-								},
-							}
-							instanceTypes = append(instanceTypes, NewInstanceType(opts))
+								}),
+							))
 						}
 					}
 				}
@@ -200,24 +273,16 @@ func InstanceTypesAssorted() []*cloudprovider.InstanceType {
 func InstanceTypes(total int) []*cloudprovider.InstanceType {
 	instanceTypes := []*cloudprovider.InstanceType{}
 	for i := range total {
-		instanceTypes = append(instanceTypes, NewInstanceType(InstanceTypeOptions{
-			Name: fmt.Sprintf("fake-it-%d", i),
-			Resources: map[corev1.ResourceName]resource.Quantity{
+		instanceTypes = append(instanceTypes, NewInstanceType(
+			fmt.Sprintf("fake-it-%d", i),
+			WithResources(corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", i+1)),
 				corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", (i+1)*2)),
 				corev1.ResourcePods:   resource.MustParse(fmt.Sprintf("%d", (i+1)*10)),
-			},
-		}))
+			}),
+		))
 	}
 	return instanceTypes
-}
-
-type InstanceTypeOptions struct {
-	Name             string
-	Offerings        cloudprovider.Offerings
-	Architecture     string
-	OperatingSystems sets.Set[string]
-	Resources        corev1.ResourceList
 }
 
 func PriceFromResources(resources corev1.ResourceList) float64 {

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -31,6 +31,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/test"
 )
 
 const (
@@ -313,6 +314,55 @@ func CounterConsumption(counterSet string, counters map[string]resource.Quantity
 			return resourcev1.Counter{Value: q}
 		}),
 	}
+}
+
+// GPUInstanceType builds a fake instance type publishing `count` GPU template devices under test.GPUDriver.
+func GPUInstanceType(name string, count int) *cloudprovider.InstanceType {
+	deviceNames := lo.Times(count, func(i int) string { return fmt.Sprintf("%s-gpu-%d", name, i) })
+	return NewInstanceType(name,
+		WithResourceSliceTemplates(ResourceSliceTemplate(test.GPUDriver, name+"-pool", Devices(deviceNames...)...)),
+	)
+}
+
+// GPUAndNICInstanceType builds a fake instance type publishing a GPU device under test.GPUDriver and a NIC device under
+// test.NICDriver, exercising multi-driver allocation on a single node.
+func GPUAndNICInstanceType(name string) *cloudprovider.InstanceType {
+	return NewInstanceType(name,
+		WithResourceSliceTemplates(
+			ResourceSliceTemplate(test.GPUDriver, name+"-gpu-pool", Devices(name+"-gpu-0")...),
+			ResourceSliceTemplate(test.NICDriver, name+"-nic-pool", Devices(name+"-nic-0")...),
+		),
+	)
+}
+
+// CapacityGPUInstanceType builds a fake instance type publishing one multi-allocatable GPU template device with the
+// given total memory capacity and an optional RequestPolicy (nil for unconstrained capacity consumption).
+func CapacityGPUInstanceType(name, totalMemory string, policy *resourcev1.CapacityRequestPolicy) *cloudprovider.InstanceType {
+	capacityOpt := WithCapacity(test.CapacityMemory, resource.MustParse(totalMemory))
+	if policy != nil {
+		capacityOpt = WithCapacityPolicy(test.CapacityMemory, resource.MustParse(totalMemory), policy)
+	}
+	return NewInstanceType(name, WithResourceSliceTemplates(
+		ResourceSliceTemplate(test.GPUDriver, name+"-pool",
+			DeviceWith(name+"-gpu-0", WithMultipleAllocations(), capacityOpt),
+		),
+	))
+}
+
+// PartitionableGPUInstanceType builds a fake instance type modeling a partitionable device: a pool with a shared
+// counter budget and `profiles` device profiles, each consuming `perProfile` counters from the budget on allocation.
+// The counter set and the devices live in separate templates under the same pool (a slice may carry either devices or
+// shared counters, never both).
+func PartitionableGPUInstanceType(name, counterSet string, budget map[string]resource.Quantity, profiles int, perProfile map[string]resource.Quantity) *cloudprovider.InstanceType {
+	deviceProfiles := lo.Times(profiles, func(i int) cloudprovider.Device {
+		return DeviceWith(fmt.Sprintf("%s-profile-%d", name, i),
+			WithConsumesCounters(CounterConsumption(counterSet, perProfile)),
+		)
+	})
+	return NewInstanceType(name, WithResourceSliceTemplates(
+		ResourceSliceTemplateWithCounters(test.GPUDriver, name+"-pool", CounterSet(counterSet, budget)),
+		ResourceSliceTemplate(test.GPUDriver, name+"-pool", deviceProfiles...),
+	))
 }
 
 // InstanceTypesAssorted create many unique instance types with varying CPU/memory/architecture/OS/zone/capacity type.

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -227,6 +227,94 @@ func Devices(names ...string) []cloudprovider.Device {
 	})
 }
 
+// DeviceOption mutates a cloudprovider.Device, used by DeviceWith to compose capacity, multi-allocation,
+// and counter-consumption shapes onto a DRA template device.
+type DeviceOption = option.Function[cloudprovider.Device]
+
+// DeviceWith builds a cloud provider DRA device with the given name and applies the provided options. It is the
+// capacity/counter-aware analog of Device, used to construct consumable-capacity and partitionable template devices.
+func DeviceWith(name string, opts ...DeviceOption) cloudprovider.Device {
+	d := cloudprovider.Device{Name: unique.Make(name)}
+	for _, opt := range opts {
+		opt(&d)
+	}
+	return d
+}
+
+// WithDeviceAttributes sets the device's selector/constraint attributes.
+func WithDeviceAttributes(attributes map[resourcev1.QualifiedName]resourcev1.DeviceAttribute) DeviceOption {
+	return func(d *cloudprovider.Device) { d.Attributes = attributes }
+}
+
+// WithMultipleAllocations marks the device as multi-allocatable, allowing it to be allocated to multiple requests
+// (the precondition for consumable-capacity sharing).
+func WithMultipleAllocations() DeviceOption {
+	return func(d *cloudprovider.Device) { d.AllowMultipleAllocations = true }
+}
+
+// WithCapacity adds a capacity dimension to the device. The value is the device's fixed total for that dimension;
+// RequestPolicy (if any) is attached separately so callers can express unconstrained capacity simply.
+func WithCapacity(name resourcev1.QualifiedName, value resource.Quantity) DeviceOption {
+	return func(d *cloudprovider.Device) {
+		if d.Capacity == nil {
+			d.Capacity = map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{}
+		}
+		cap := d.Capacity[name]
+		cap.Value = value
+		d.Capacity[name] = cap
+	}
+}
+
+// WithCapacityPolicy adds a capacity dimension with a RequestPolicy (Default / ValidValues / ValidRange) constraining
+// how much of the dimension a single request may consume. The device must be multi-allocatable for a policy to apply.
+func WithCapacityPolicy(name resourcev1.QualifiedName, value resource.Quantity, policy *resourcev1.CapacityRequestPolicy) DeviceOption {
+	return func(d *cloudprovider.Device) {
+		if d.Capacity == nil {
+			d.Capacity = map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{}
+		}
+		d.Capacity[name] = resourcev1.DeviceCapacity{Value: value, RequestPolicy: policy}
+	}
+}
+
+// WithConsumesCounters declares the shared counters this device draws from on allocation (the partitionable-device
+// path). Each consumption references a counter set by name and the per-counter amounts it consumes.
+func WithConsumesCounters(consumes ...resourcev1.DeviceCounterConsumption) DeviceOption {
+	return func(d *cloudprovider.Device) { d.ConsumesCounters = consumes }
+}
+
+// ResourceSliceTemplateWithCounters builds a ResourceSliceTemplate that declares shared counter sets and no devices.
+// A ResourceSlice may carry either devices or shared counters, never both, so a partitionable pool pairs this
+// counter-set template with a separate device template (built via ResourceSliceTemplate) under the same pool.
+func ResourceSliceTemplateWithCounters(driver, pool string, counterSets ...resourcev1.CounterSet) cloudprovider.ResourceSliceTemplate {
+	return cloudprovider.ResourceSliceTemplate{
+		Driver:         unique.Make(driver),
+		Pool:           cloudprovider.ResourcePool{Name: unique.Make(pool)},
+		SharedCounters: counterSets,
+	}
+}
+
+// CounterSet builds a shared counter set with the given name and per-counter quantities. It is a convenience for
+// constructing the SharedCounters of a partitionable pool.
+func CounterSet(name string, counters map[string]resource.Quantity) resourcev1.CounterSet {
+	return resourcev1.CounterSet{
+		Name: name,
+		Counters: lo.MapValues(counters, func(q resource.Quantity, _ string) resourcev1.Counter {
+			return resourcev1.Counter{Value: q}
+		}),
+	}
+}
+
+// CounterConsumption builds a DeviceCounterConsumption referencing a counter set by name and the per-counter amounts
+// consumed from it, for use with WithConsumesCounters.
+func CounterConsumption(counterSet string, counters map[string]resource.Quantity) resourcev1.DeviceCounterConsumption {
+	return resourcev1.DeviceCounterConsumption{
+		CounterSet: counterSet,
+		Counters: lo.MapValues(counters, func(q resource.Quantity, _ string) resourcev1.Counter {
+			return resourcev1.Counter{Value: q}
+		}),
+	}
+}
+
 // InstanceTypesAssorted create many unique instance types with varying CPU/memory/architecture/OS/zone/capacity type.
 func InstanceTypesAssorted() []*cloudprovider.InstanceType {
 	var instanceTypes []*cloudprovider.InstanceType

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -94,7 +94,8 @@ func NewControllers(
 	opts ...option.Function[ControllerOptions],
 ) []controller.Controller {
 	o := option.Resolve(opts...)
-	p := provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster, clock)
+	deviceAllocationController := deviceallocation.NewController(kubeClient)
+	p := provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster, clock, deviceAllocationController)
 	evictionQueue := terminator.NewQueue(kubeClient, recorder)
 	disruptionQueue := disruption.NewQueue(kubeClient, recorder, cluster, clock, p)
 	npState := nodepoolhealth.NewState()
@@ -127,7 +128,7 @@ func NewControllers(
 	}
 
 	if !options.FromContext(ctx).IgnoreDRARequests {
-		controllers = append(controllers, deviceallocation.NewController(kubeClient))
+		controllers = append(controllers, deviceAllocationController)
 	}
 
 	if !options.FromContext(ctx).DisableClusterStateObservability {
@@ -162,7 +163,7 @@ func NewControllers(
 	}
 
 	if options.FromContext(ctx).FeatureGates.StaticCapacity {
-		controllers = append(controllers, staticprovisioning.NewController(kubeClient, cluster, recorder, cloudProvider, p, clock))
+		controllers = append(controllers, staticprovisioning.NewController(kubeClient, cluster, recorder, cloudProvider, p, clock, deviceAllocationController))
 		controllers = append(controllers, staticdeprovisioning.NewController(kubeClient, cluster, cloudProvider, clock, recorder))
 	}
 

--- a/pkg/controllers/disruption/consolidation_dra_test.go
+++ b/pkg/controllers/disruption/consolidation_dra_test.go
@@ -55,20 +55,23 @@ var _ = Describe("Consolidation/DRA", func() {
 		nodePool.Spec.Disruption.ConsolidateAfter = v1.MustParseNillableDuration("0s")
 	})
 
-	// simulateConsolidation builds a disruption candidate for the given node and runs SimulateScheduling against it,
+	// simulateConsolidation builds a disruption candidate for each given node and runs SimulateScheduling against them,
 	// reconciling the deviceallocation controller first so the allocator sees the current allocated-device state. It
-	// returns the simulation results, which describe where the candidate's pods would reschedule.
-	simulateConsolidation := func(node *corev1.Node) pscheduling.Results {
+	// returns the simulation results, which describe where the candidates' pods would reschedule.
+	simulateConsolidation := func(nodes ...*corev1.Node) pscheduling.Results {
 		GinkgoHelper()
 		ExpectDeviceAllocationReconciled(ctx, env.Client, draController)
 		pdbs, err := pdb.NewLimits(ctx, env.Client)
 		Expect(err).To(Succeed())
 		nodePoolMap, nodePoolToInstanceTypesMap, err := disruption.BuildNodePoolMap(ctx, env.Client, cloudProvider)
 		Expect(err).To(Succeed())
-		stateNode := ExpectStateNodeExists(cluster, node)
-		candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, stateNode, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue, disruption.GracefulDisruptionClass)
-		Expect(err).To(Succeed())
-		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, []pscheduling.Options{pscheduling.IsConsolidationSimulation}, candidate)
+		candidates := lo.Map(nodes, func(node *corev1.Node, _ int) *disruption.Candidate {
+			stateNode := ExpectStateNodeExists(cluster, node)
+			candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, stateNode, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue, disruption.GracefulDisruptionClass)
+			Expect(err).To(Succeed())
+			return candidate
+		})
+		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, []pscheduling.Options{pscheduling.IsConsolidationSimulation}, candidates...)
 		Expect(err).To(Succeed())
 		return results
 	}
@@ -208,5 +211,71 @@ var _ = Describe("Consolidation/DRA", func() {
 		// reschedule and consolidation cannot proceed.
 		Expect(results.NewNodeClaims).To(BeEmpty())
 		Expect(results.AllNonPendingPodsScheduled()).To(BeFalse())
+	})
+
+	It("re-allocates devices from multiple candidate nodes onto one replacement (B, multi-candidate)", func() {
+		// Two candidate nodes, each hosting a GPU pod holding its node's published device. A single replacement instance
+		// type with two template GPUs can host both pods. Multi-node consolidation must free both candidates' devices
+		// (B1 over all candidates) and re-allocate both claims (B2) onto the one replacement.
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.GPUInstanceType("gpu-it", 2)}
+		ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", test.GPUDriver))
+		_, node1 := gpuNodeClaimAndNode("gpu-it")
+		_, node2 := gpuNodeClaimAndNode("gpu-it")
+		ExpectApplied(ctx, env.Client, test.NodeLocalSlice(node1, test.GPUDriver, "incluster-gpu-0"))
+		ExpectApplied(ctx, env.Client, test.NodeLocalSlice(node2, test.GPUDriver, "incluster-gpu-0"))
+		pod1 := gpuPodOnNode(node1, "gpu-claim-1", test.NodeLocalPoolName(test.GPUDriver, node1.Name), "incluster-gpu-0")
+		pod2 := gpuPodOnNode(node2, "gpu-claim-2", test.NodeLocalPoolName(test.GPUDriver, node2.Name), "incluster-gpu-0")
+
+		results := simulateConsolidation(node1, node2)
+
+		// Both pods reschedule with no error onto a single replacement NodeClaim (its two template GPUs satisfy both
+		// reclassified claims). Neither candidate node is reused as a scheduling target.
+		Expect(results.PodErrors[pod1]).To(BeNil())
+		Expect(results.PodErrors[pod2]).To(BeNil())
+		Expect(results.NewNodeClaims).To(HaveLen(1))
+		Expect(results.AllNonPendingPodsScheduled()).To(BeTrue())
+		for _, en := range results.ExistingNodes {
+			Expect([]string{node1.Name, node2.Name}).ToNot(ContainElement(en.Name()), "candidate nodes must not be scheduling targets")
+		}
+	})
+
+	It("reclaims only the candidate's share of a shared device, leaving the live pod's share (B, partial)", func() {
+		// A cluster-wide multi-allocatable device with 16Gi capacity, shared between a live pod (4Gi) on a surviving node
+		// and a candidate pod (10Gi). Consolidating the candidate must reclaim only its 10Gi share — the device stays
+		// pinned for the live pod — and re-allocate the candidate's claim back onto the same shared device.
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("no-gpu-it")}
+		ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", test.GPUDriver))
+		ExpectApplied(ctx, env.Client, test.SharedCapacitySlice("shared-gpu-pool", test.GPUDriver, "shared-gpu-0", "16Gi"))
+
+		// Live pod on a surviving (non-candidate) node holds 4Gi — this share must NOT be reclaimed.
+		_, liveNode := gpuNodeClaimAndNode("no-gpu-it")
+		livePod := test.Pod()
+		ExpectApplied(ctx, env.Client, livePod)
+		ExpectManualBinding(ctx, env.Client, livePod, liveNode)
+		ExpectApplied(ctx, env.Client, test.AllocatedSharedClaim("live-claim", "shared-gpu-pool", test.GPUDriver, "shared-gpu-0", test.CapacityRequest("4Gi"), test.PodConsumer(livePod)))
+
+		// Candidate pod holds 10Gi of the same shared device.
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		_, candidateNode := gpuNodeClaimAndNode("no-gpu-it")
+		candidatePod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "ReplicaSet", Name: rs.Name, UID: rs.UID,
+				Controller: lo.ToPtr(true), BlockOwnerDeletion: lo.ToPtr(true),
+			}}},
+			ResourceClaims:          []corev1.PodResourceClaim{test.PodResourceClaimReference("gpu", "candidate-claim")},
+			ContainerResourceClaims: []corev1.ResourceClaim{{Name: "gpu"}},
+		})
+		ExpectApplied(ctx, env.Client, candidatePod)
+		ExpectManualBinding(ctx, env.Client, candidatePod, candidateNode)
+		ExpectApplied(ctx, env.Client, test.AllocatedSharedClaim("candidate-claim", "shared-gpu-pool", test.GPUDriver, "shared-gpu-0", test.CapacityRequest("10Gi"), test.PodConsumer(candidatePod)))
+
+		results := simulateConsolidation(candidateNode)
+
+		// The candidate pod reschedules: its 10Gi share is reclaimed (B1 partial subtraction) and its claim reclassified
+		// (B2), re-allocating onto the shared device whose remaining capacity (16 - 4 live = 12Gi) now fits 10Gi. The
+		// live pod's 4Gi is untouched. no-gpu-it provides no template GPU, so the cluster-wide device is the only option.
+		Expect(results.PodErrors[candidatePod]).To(BeNil())
+		Expect(results.AllNonPendingPodsScheduled()).To(BeTrue())
 	})
 })

--- a/pkg/controllers/disruption/consolidation_dra_test.go
+++ b/pkg/controllers/disruption/consolidation_dra_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
+	pscheduling "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	"sigs.k8s.io/karpenter/pkg/utils/pdb"
+)
+
+// These tests exercise DRA behavior through the disruption/consolidation SimulateScheduling path. They drive
+// SimulateScheduling directly with a consolidation candidate (rather than the full reconcile + queue machinery), which
+// is the same approach the suite uses elsewhere and isolates the two DRA-specific concerns:
+//   - (A) ResourceSlices owned by a candidate node (simulated for deletion) are not considered scheduling targets.
+//   - (B) Devices held by candidate pods (which would be deallocated) are freed and their claims re-allocated.
+var _ = Describe("Consolidation/DRA", func() {
+	var nodePool *v1.NodePool
+
+	BeforeEach(func() {
+		if env.Version.Minor() < 34 {
+			Skip("DRA is only available in K8s versions >= 1.34.x")
+		}
+		// Enable DRA (gated off by default). The suite's BeforeEach resets options, and runs before this one, so this
+		// re-enables DRA for the consolidation simulation.
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{IgnoreDRARequests: lo.ToPtr(false)}))
+		nodePool = test.NodePool()
+		nodePool.Spec.Disruption.ConsolidationPolicy = v1.ConsolidationPolicyWhenEmptyOrUnderutilized
+		nodePool.Spec.Disruption.ConsolidateAfter = v1.MustParseNillableDuration("0s")
+	})
+
+	// simulateConsolidation builds a disruption candidate for the given node and runs SimulateScheduling against it,
+	// reconciling the deviceallocation controller first so the allocator sees the current allocated-device state. It
+	// returns the simulation results, which describe where the candidate's pods would reschedule.
+	simulateConsolidation := func(node *corev1.Node) pscheduling.Results {
+		GinkgoHelper()
+		ExpectDeviceAllocationReconciled(ctx, env.Client, draController)
+		pdbs, err := pdb.NewLimits(ctx, env.Client)
+		Expect(err).To(Succeed())
+		nodePoolMap, nodePoolToInstanceTypesMap, err := disruption.BuildNodePoolMap(ctx, env.Client, cloudProvider)
+		Expect(err).To(Succeed())
+		stateNode := ExpectStateNodeExists(cluster, node)
+		candidate, err := disruption.NewCandidate(ctx, env.Client, recorder, env.Clock, stateNode, pdbs, nodePoolMap, nodePoolToInstanceTypesMap, queue, disruption.GracefulDisruptionClass)
+		Expect(err).To(Succeed())
+		results, err := disruption.SimulateScheduling(ctx, env.Client, cluster, prov, env.Clock, recorder, []pscheduling.Options{pscheduling.IsConsolidationSimulation}, candidate)
+		Expect(err).To(Succeed())
+		return results
+	}
+
+	// gpuNodeClaimAndNode builds a managed NodeClaim+Node pair of the given instance type, applies it, and informs
+	// cluster state so it is evaluated as an existing node. The node carries a hostname label and a UID so node-local
+	// published ResourceSlices can target it.
+	gpuNodeClaimAndNode := func(instanceType string) (*v1.NodeClaim, *corev1.Node) {
+		GinkgoHelper()
+		nodeClaim, node := test.NodeClaimAndNode(v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey:            nodePool.Name,
+					corev1.LabelInstanceTypeStable: instanceType,
+				},
+			},
+			Status: v1.NodeClaimStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("16"),
+					corev1.ResourcePods: resource.MustParse("100"),
+				},
+			},
+		})
+		node.Labels[corev1.LabelHostname] = node.Name
+		ExpectApplied(ctx, env.Client, nodeClaim, node)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{node}, []*v1.NodeClaim{nodeClaim})
+		return nodeClaim, ExpectExists(ctx, env.Client, node)
+	}
+
+	// gpuPodOnNode builds a reschedulable (ReplicaSet-owned) pod with a GPU ResourceClaim, binds it to the node, and
+	// marks the claim allocated to the node's published device and reserved for the pod. This is the state a consolidation
+	// candidate node is in: a pod holding a device that must be re-allocated if the node is removed.
+	gpuPodOnNode := func(node *corev1.Node, claimName, pool, device string) *corev1.Pod {
+		GinkgoHelper()
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "ReplicaSet", Name: rs.Name, UID: rs.UID,
+				Controller: lo.ToPtr(true), BlockOwnerDeletion: lo.ToPtr(true),
+			}}},
+			ResourceClaims:          []corev1.PodResourceClaim{test.PodResourceClaimReference("gpu", claimName)},
+			ContainerResourceClaims: []corev1.ResourceClaim{{Name: "gpu"}},
+		})
+		ExpectApplied(ctx, env.Client, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+		claim := test.AllocatedClusterWideClaim(claimName, pool, test.GPUDriver, device, test.PodConsumer(pod))
+		ExpectApplied(ctx, env.Client, claim)
+		return pod
+	}
+
+	It("re-allocates a candidate pod's device onto a replacement (B, positive)", func() {
+		// One GPU instance type with a single template GPU. The candidate node hosts a pod holding the node's published
+		// GPU. Consolidating the candidate must free that device and re-allocate the claim onto a replacement NodeClaim's
+		// template GPU — so the simulation produces a replacement and no pod errors.
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.GPUInstanceType("gpu-it", 1)}
+		ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", test.GPUDriver))
+		_, node := gpuNodeClaimAndNode("gpu-it")
+		ExpectApplied(ctx, env.Client, test.NodeLocalSlice(node, test.GPUDriver, "incluster-gpu-0"))
+		pod := gpuPodOnNode(node, "gpu-claim", test.NodeLocalPoolName(test.GPUDriver, node.Name), "incluster-gpu-0")
+
+		results := simulateConsolidation(node)
+
+		// The pod reschedules with no error, onto a freshly launched NodeClaim (the candidate's published slice is
+		// excluded, so the only way to satisfy the claim is a new node's template GPU).
+		Expect(results.PodErrors[pod]).To(BeNil())
+		Expect(results.NewNodeClaims).To(HaveLen(1))
+	})
+
+	It("does not target a candidate node's published device (A, positive)", func() {
+		// Two GPU instance types' worth of nodes: a candidate node C (publishing a GPU) and a second node K with a free
+		// published GPU but no spare CPU room is not used — instead we assert the replacement is a NEW node, never C
+		// itself, proving C's slice was excluded from the scheduling universe.
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.GPUInstanceType("gpu-it", 1)}
+		ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", test.GPUDriver))
+		_, node := gpuNodeClaimAndNode("gpu-it")
+		ExpectApplied(ctx, env.Client, test.NodeLocalSlice(node, test.GPUDriver, "incluster-gpu-0"))
+		pod := gpuPodOnNode(node, "gpu-claim", test.NodeLocalPoolName(test.GPUDriver, node.Name), "incluster-gpu-0")
+
+		results := simulateConsolidation(node)
+
+		Expect(results.PodErrors[pod]).To(BeNil())
+		// The replacement is a new NodeClaim, and it does not reuse the candidate node as an existing scheduling target.
+		Expect(results.NewNodeClaims).To(HaveLen(1))
+		for _, en := range results.ExistingNodes {
+			Expect(en.Name()).ToNot(Equal(node.Name), "the candidate node must not be a scheduling target")
+		}
+	})
+
+	It("does not consolidate when the candidate's claim cannot be satisfied elsewhere (B, negative)", func() {
+		// The only instance type that provides the GPU is the candidate's own, and it offers exactly one device which the
+		// candidate pod holds. Once freed it can only be re-acquired on a brand-new node of the same type — which is a
+		// valid replacement. To make it genuinely unsatisfiable, restrict the NodePool so no instance type provides a GPU
+		// template: the claim cannot be re-allocated anywhere, so the pod errors and consolidation cannot proceed.
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("no-gpu-it")}
+		ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", test.GPUDriver))
+		// The candidate node is a gpu-it that no longer exists in the offered instance types; its published slice is
+		// excluded as a candidate, and no other node/type can provide the device.
+		_, node := gpuNodeClaimAndNode("gpu-it")
+		ExpectApplied(ctx, env.Client, test.NodeLocalSlice(node, test.GPUDriver, "incluster-gpu-0"))
+		pod := gpuPodOnNode(node, "gpu-claim", test.NodeLocalPoolName(test.GPUDriver, node.Name), "incluster-gpu-0")
+
+		results := simulateConsolidation(node)
+		_ = pod
+
+		// The claim can't be re-allocated, so the candidate pod fails to schedule and no replacement is produced —
+		// consolidation cannot proceed. (PodErrors is keyed by the scheduler's internal pod copies, so we assert on the
+		// pointer-independent signals.)
+		Expect(results.NewNodeClaims).To(BeEmpty())
+		Expect(results.AllNonPendingPodsScheduled()).To(BeFalse())
+	})
+
+	It("does not free a device held by a live pod on a non-candidate node (A, negative)", func() {
+		// A single cluster-wide GPU device is held by a LIVE pod on a non-candidate node. The candidate pod also needs a
+		// GPU. Because the live pod isn't deleting, its device is neither freed nor its claim reclassified, so there is no
+		// second GPU available and the candidate pod cannot reschedule.
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("no-gpu-it")}
+		ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", test.GPUDriver))
+		// One cluster-wide device total.
+		ExpectApplied(ctx, env.Client, test.ClusterWideSlice("shared-gpu-pool", test.GPUDriver, "shared-gpu-0"))
+
+		// Live pod on a non-candidate node holds the only device.
+		_, liveNode := gpuNodeClaimAndNode("no-gpu-it")
+		livePod := test.Pod()
+		ExpectApplied(ctx, env.Client, livePod)
+		ExpectManualBinding(ctx, env.Client, livePod, liveNode)
+		ExpectApplied(ctx, env.Client, test.AllocatedClusterWideClaim("held-claim", "shared-gpu-pool", test.GPUDriver, "shared-gpu-0", test.PodConsumer(livePod)))
+
+		// Candidate node hosts a pod that also needs a GPU.
+		_, candidateNode := gpuNodeClaimAndNode("no-gpu-it")
+		candidatePod := gpuPodOnNode(candidateNode, "candidate-claim", "shared-gpu-pool", "shared-gpu-0")
+
+		results := simulateConsolidation(candidateNode)
+		_ = candidatePod
+
+		// The live pod's device is not available (not freed, claim not reclassified), so the candidate pod can't
+		// reschedule and consolidation cannot proceed.
+		Expect(results.NewNodeClaims).To(BeEmpty())
+		Expect(results.AllNonPendingPodsScheduled()).To(BeFalse())
+	})
+})

--- a/pkg/controllers/disruption/consolidation_dra_test.go
+++ b/pkg/controllers/disruption/consolidation_dra_test.go
@@ -240,6 +240,10 @@ var _ = Describe("Consolidation/DRA", func() {
 	})
 
 	It("reclaims only the candidate's share of a shared device, leaving the live pod's share (B, partial)", func() {
+		// Multi-allocatable devices / consumable capacity require the DRAConsumableCapacity feature, GA in k8s 1.36.
+		if env.Version.Minor() < 36 {
+			Skip("Consumable capacity requires K8s versions >= 1.36.x (DRAConsumableCapacity feature gate)")
+		}
 		// A cluster-wide multi-allocatable device with 16Gi capacity, shared between a live pod (4Gi) on a surviving node
 		// and a candidate pod (10Gi). Consolidating the candidate must reclaim only its 10Gi share — the device stays
 		// pinned for the live pod — and re-allocate the candidate's claim back onto the same shared device.

--- a/pkg/controllers/disruption/consolidation_test.go
+++ b/pkg/controllers/disruption/consolidation_test.go
@@ -1460,32 +1460,26 @@ var _ = Describe("Consolidation", func() {
 					Values:   []string{v1.CapacityTypeOnDemand},
 				},
 			}
-			currentInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "current-on-demand",
-				Resources: corev1.ResourceList{
+			currentInstanceType := fake.NewInstanceType("current-on-demand",
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("5"),
-				},
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:    true,
-						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
-						Price:        0.5,
-					},
-				},
-			})
-			otherInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "other-on-demand",
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(cloudprovider.Offering{
+					Available:    true,
+					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
+					Price:        0.5,
+				}),
+			)
+			otherInstanceType := fake.NewInstanceType("other-on-demand",
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("5"),
-				},
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:    true,
-						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
-						Price:        0.4,
-					},
-				},
-			})
+				}),
+				fake.WithOfferings(cloudprovider.Offering{
+					Available:    true,
+					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
+					Price:        0.4,
+				}),
+			)
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 				currentInstanceType,
 				otherInstanceType,
@@ -2198,36 +2192,32 @@ var _ = Describe("Consolidation", func() {
 			Entry("if the candidate is spot node", true),
 		)
 		It("won't replace node if any spot replacement is more expensive", func() {
-			currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "current-on-demand",
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:    false,
-						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
-						Price:        0.5,
-					},
-				},
-			})
-			replacementInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "potential-spot-replacement",
-				Offerings: []*cloudprovider.Offering{
-					{
+			currentInstance := fake.NewInstanceType("current-on-demand",
+				fake.WithOfferings(cloudprovider.Offering{
+					Available:    false,
+					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
+					Price:        0.5,
+				}),
+			)
+			replacementInstance := fake.NewInstanceType("potential-spot-replacement",
+				fake.WithOfferings(
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1a"}),
 						Price:        1.0,
 					},
-					{
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1b"}),
 						Price:        0.2,
 					},
-					{
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1c"}),
 						Price:        0.4,
 					},
-				},
-			})
+				),
+			)
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 				currentInstance,
 				replacementInstance,
@@ -2281,41 +2271,37 @@ var _ = Describe("Consolidation", func() {
 			ExpectExists(ctx, env.Client, node)
 		})
 		It("won't replace on-demand node if on-demand replacement is more expensive", func() {
-			currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "current-on-demand",
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:    false,
-						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
-						Price:        0.5,
-					},
-				},
-			})
-			replacementInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "on-demand-replacement",
-				Offerings: []*cloudprovider.Offering{
-					{
+			currentInstance := fake.NewInstanceType("current-on-demand",
+				fake.WithOfferings(cloudprovider.Offering{
+					Available:    false,
+					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
+					Price:        0.5,
+				}),
+			)
+			replacementInstance := fake.NewInstanceType("on-demand-replacement",
+				fake.WithOfferings(
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
 						Price:        0.6,
 					},
-					{
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1b"}),
 						Price:        0.6,
 					},
-					{
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1b"}),
 						Price:        0.2,
 					},
-					{
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1c"}),
 						Price:        0.3,
 					},
-				},
-			})
+				),
+			)
 
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 				currentInstance,
@@ -3229,22 +3215,20 @@ var _ = Describe("Consolidation", func() {
 			ExpectNotFound(ctx, env.Client, nodeClaim, node)
 		})
 		It("should consider initialized nodes before uninitialized nodes", func() {
-			defaultInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "default-instance-type",
-				Resources: corev1.ResourceList{
+			defaultInstanceType := fake.NewInstanceType("default-instance-type",
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("3"),
 					corev1.ResourceMemory: resource.MustParse("3Gi"),
 					corev1.ResourcePods:   resource.MustParse("110"),
-				},
-			})
-			smallInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "small-instance-type",
-				Resources: corev1.ResourceList{
+				}),
+			)
+			smallInstanceType := fake.NewInstanceType("small-instance-type",
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
 					corev1.ResourcePods:   resource.MustParse("10"),
-				},
-			})
+				}),
+			)
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 				defaultInstanceType,
 				smallInstanceType,

--- a/pkg/controllers/disruption/drift_test.go
+++ b/pkg/controllers/disruption/drift_test.go
@@ -966,27 +966,21 @@ var _ = Describe("Drift", func() {
 			Expect(node.Spec.Taints).ToNot(ContainElement(v1.DisruptedNoScheduleTaint))
 		})
 		It("can replace drifted nodes with multiple nodes", func() {
-			currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "current-on-demand",
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:    false,
-						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
-						Price:        0.5,
-					},
-				},
-			})
-			replacementInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "replacement-on-demand",
-				Offerings: []*cloudprovider.Offering{
-					{
-						Available:    true,
-						Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
-						Price:        0.3,
-					},
-				},
-				Resources: map[corev1.ResourceName]resource.Quantity{corev1.ResourceCPU: resource.MustParse("3")},
-			})
+			currentInstance := fake.NewInstanceType("current-on-demand",
+				fake.WithOfferings(cloudprovider.Offering{
+					Available:    false,
+					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
+					Price:        0.5,
+				}),
+			)
+			replacementInstance := fake.NewInstanceType("replacement-on-demand",
+				fake.WithOfferings(cloudprovider.Offering{
+					Available:    true,
+					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
+					Price:        0.3,
+				}),
+				fake.WithResources(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")}),
+			)
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 				currentInstance,
 				replacementInstance,

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -81,12 +81,17 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	if err != nil {
 		return scheduling.Results{}, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
 	}
+	// candidatePods are the pods on consolidation candidate nodes that we will reschedule. Their UIDs feed
+	// deletingPodUIDs below so the DRA allocator frees the devices they hold and re-allocates their claims onto the
+	// replacement capacity, mirroring how pods on already-deleting nodes are treated.
+	var candidatePods []*corev1.Pod
 	for _, n := range candidates {
 		currentlyReschedulablePods := lo.Filter(n.reschedulablePods, func(p *corev1.Pod, _ int) bool {
 			return pdbs.IsCurrentlyReschedulable(p, clk, recorder)
 		})
-		pods = append(pods, currentlyReschedulablePods...)
+		candidatePods = append(candidatePods, currentlyReschedulablePods...)
 	}
+	pods = append(pods, candidatePods...)
 
 	// We get the pods that are on nodes that are deleting
 	deletingNodePods, err := deletingNodes.CurrentlyReschedulablePods(ctx, kubeClient, clk, recorder)
@@ -101,7 +106,9 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	}
 	opts = append(opts, scheduling.MinValuesPolicy(options.FromContext(ctx).MinValuesPolicy))
 	opts = append(opts, schedulerOpts...)
-	deletingPodUIDs := sets.New(lo.Map(deletingNodePods, func(p *corev1.Pod, _ int) types.UID { return p.UID })...)
+	// Both consolidation candidate pods and pods on already-deleting nodes are migrating off their current nodes, so
+	// the DRA allocator should treat the devices they hold as available for reallocation (and re-allocate their claims).
+	deletingPodUIDs := sets.New(lo.Map(append(candidatePods, deletingNodePods...), func(p *corev1.Pod, _ int) types.UID { return p.UID })...)
 	scheduler, err := provisioner.NewScheduler(
 		log.IntoContext(ctx, operatorlogging.NopLogger),
 		pods,

--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -100,10 +101,12 @@ func SimulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	}
 	opts = append(opts, scheduling.MinValuesPolicy(options.FromContext(ctx).MinValuesPolicy))
 	opts = append(opts, schedulerOpts...)
+	deletingPodUIDs := sets.New(lo.Map(deletingNodePods, func(p *corev1.Pod, _ int) types.UID { return p.UID })...)
 	scheduler, err := provisioner.NewScheduler(
 		log.IntoContext(ctx, operatorlogging.NopLogger),
 		pods,
 		stateNodes,
+		deletingPodUIDs,
 		opts...,
 	)
 	if err != nil {

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
 	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
@@ -99,7 +100,7 @@ var _ = BeforeSuite(func() {
 	nodeStateController = informer.NewNodeController(env.Client, cluster)
 	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 	recorder = test.NewEventRecorder()
-	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, env.Clock)
+	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, env.Clock, deviceallocation.NewController(env.Client))
 	queue = disruption.NewQueue(env.Client, recorder, cluster, env.Clock, prov)
 })
 
@@ -461,7 +462,7 @@ var _ = Describe("Simulate Scheduling", func() {
 		hangCreateClient := newHangCreateClient(env.Client)
 		defer hangCreateClient.Stop()
 
-		p := provisioning.NewProvisioner(hangCreateClient, recorder, cloudProvider, cluster, env.Clock)
+		p := provisioning.NewProvisioner(hangCreateClient, recorder, cloudProvider, cluster, env.Clock, deviceallocation.NewController(hangCreateClient))
 		q := disruption.NewQueue(hangCreateClient, recorder, cluster, env.Clock, p)
 		dc := disruption.NewController(env.Clock, hangCreateClient, p, cloudProvider, recorder, cluster, q)
 
@@ -531,36 +532,32 @@ var _ = Describe("Disruption Taints", func() {
 	var nodeClaim *v1.NodeClaim
 	var node *corev1.Node
 	BeforeEach(func() {
-		currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "current-on-demand",
-			Offerings: []*cloudprovider.Offering{
-				{
-					Available:    false,
-					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
-					Price:        1.5,
-				},
-			},
-		})
-		replacementInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "spot-replacement",
-			Offerings: []*cloudprovider.Offering{
-				{
+		currentInstance := fake.NewInstanceType("current-on-demand",
+			fake.WithOfferings(cloudprovider.Offering{
+				Available:    false,
+				Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
+				Price:        1.5,
+			}),
+		)
+		replacementInstance := fake.NewInstanceType("spot-replacement",
+			fake.WithOfferings(
+				cloudprovider.Offering{
 					Available:    true,
 					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1a"}),
 					Price:        1.0,
 				},
-				{
+				cloudprovider.Offering{
 					Available:    true,
 					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1b"}),
 					Price:        0.2,
 				},
-				{
+				cloudprovider.Offering{
 					Available:    true,
 					Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1c"}),
 					Price:        0.4,
 				},
-			},
-		})
+			),
+		)
 		nodePool = test.NodePool()
 		nodeClaim, node = test.NodeClaimAndNode(v1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -118,6 +118,12 @@ var _ = BeforeEach(func() {
 
 	recorder.Reset() // Reset the events that we captured during the run
 
+	// Rebuild the DRA device-allocation controller and the provisioner bound to it each test so DRA tracking state
+	// (which the controller accumulates across reconciles and never resets) doesn't leak between specs. This must
+	// happen before the disruptionController and queue below, which capture prov. Mirrors the provisioning suite.
+	draController = deviceallocation.NewController(env.Client)
+	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, env.Clock, draController)
+
 	// Ensure that we reset the disruption controller's methods after each test run
 	disruptionController = disruption.NewController(env.Clock, env.Client, prov, cloudProvider, recorder, cluster, queue, disruption.WithMethods(NewMethodsWithNopValidator()...))
 	env.Clock.SetTime(time.Now())

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -70,6 +70,7 @@ var cluster *state.Cluster
 var disruptionController *disruption.Controller
 var pricingController *informer.PricingController
 var prov *provisioning.Provisioner
+var draController *deviceallocation.Controller
 var cloudProvider *fake.CloudProvider
 var nodeStateController *informer.NodeController
 var nodeClaimStateController *informer.NodeClaimController
@@ -100,7 +101,8 @@ var _ = BeforeSuite(func() {
 	nodeStateController = informer.NewNodeController(env.Client, cluster)
 	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 	recorder = test.NewEventRecorder()
-	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, env.Clock, deviceallocation.NewController(env.Client))
+	draController = deviceallocation.NewController(env.Client)
+	prov = provisioning.NewProvisioner(env.Client, recorder, cloudProvider, cluster, env.Clock, draController)
 	queue = disruption.NewQueue(env.Client, recorder, cluster, env.Clock, prov)
 })
 

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -61,6 +61,17 @@ type ClaimMetadata struct {
 	Contributions map[cloudprovider.DeviceID]DeviceContribution
 }
 
+// ContributionMetadata records a single claim's contribution to a shared device's consumed capacity, paired with the
+// pods that reserve that claim. It lets consumers reason about which portion of a shared device's aggregated capacity
+// belongs to which pods — for example, to free only the capacity held by pods that are being deleted.
+type ContributionMetadata struct {
+	// PodUIDs is the set of pod UIDs that reserve the claim contributing this capacity. Non-pod consumer UIDs are
+	// excluded. Empty when the claim is reserved but not by any pod.
+	PodUIDs []types.UID
+	// ConsumedCapacity is the capacity this single claim consumes on the device.
+	ConsumedCapacity map[resourcev1.QualifiedName]resource.Quantity
+}
+
 // Metadata contains supplementary information about an allocated device, derived from the ReservedFor status of all
 // ResourceClaims that reference it.
 type DeviceMetadata struct {
@@ -77,6 +88,11 @@ type DeviceMetadata struct {
 	// ConsumedCapacity is the aggregated capacity consumed across all claims referencing this device.
 	// Only populated when Shared is true.
 	ConsumedCapacity map[resourcev1.QualifiedName]resource.Quantity
+	// Contributions is the per-claim breakdown of consumed capacity on this device, one entry per referencing claim
+	// that consumes capacity, each paired with the pods reserving that claim. Only populated when Shared is true. This
+	// is the per-claim view that ConsumedCapacity aggregates; consumers that need to attribute capacity to specific
+	// pods (e.g. to release only a deleting pod's share) use this instead of the aggregate.
+	Contributions []ContributionMetadata
 }
 
 type Controller struct {
@@ -271,6 +287,10 @@ func (c *Controller) computeDeviceMetadata(device cloudprovider.DeviceID) Device
 		if contributions.ConsumedCapacity != nil {
 			meta.Shared = true
 			meta.ConsumedCapacity = addCapacity(meta.ConsumedCapacity, contributions.ConsumedCapacity)
+			meta.Contributions = append(meta.Contributions, ContributionMetadata{
+				PodUIDs:          claimMeta.PodUIDs,
+				ConsumedCapacity: contributions.ConsumedCapacity,
+			})
 		}
 	}
 	return meta

--- a/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/suite_test.go
@@ -809,6 +809,53 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			})
 		})
 
+		It("surfaces per-claim contributions paired with their reserving pods", func() {
+			claimA := withReservedFor(
+				resourceClaim("claim-a", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+					"memory":      resource.MustParse("256Mi"),
+					"connections": resource.MustParse("1"),
+				})),
+				podRef("pod-a", "uid-a"),
+			)
+			claimB := withReservedFor(
+				resourceClaim("claim-b", deviceResultWithCapacity("device-0", map[resourcev1.QualifiedName]resource.Quantity{
+					"memory":      resource.MustParse("128Mi"),
+					"connections": resource.MustParse("3"),
+				})),
+				podRef("pod-b", "uid-b"),
+			)
+			ExpectApplied(ctx, env.Client, claimA, claimB)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimA))
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(claimB))
+
+			seq, err := controller.AllocatedDevices(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			devices := collectDevices(seq)
+			meta := devices[deviceID("device-0")]
+			Expect(meta.Shared).To(BeTrue())
+			// One contribution per referencing claim, each attributed to that claim's reserving pod and carrying only
+			// that claim's capacity (not the aggregate).
+			Expect(meta.Contributions).To(HaveLen(2))
+			contributionForPod := func(uid types.UID) deviceallocation.ContributionMetadata {
+				for _, c := range meta.Contributions {
+					for _, podUID := range c.PodUIDs {
+						if podUID == uid {
+							return c
+						}
+					}
+				}
+				return deviceallocation.ContributionMetadata{}
+			}
+			expectCapacity(contributionForPod("uid-a").ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
+				"memory":      resource.MustParse("256Mi"),
+				"connections": resource.MustParse("1"),
+			})
+			expectCapacity(contributionForPod("uid-b").ConsumedCapacity, map[resourcev1.QualifiedName]resource.Quantity{
+				"memory":      resource.MustParse("128Mi"),
+				"connections": resource.MustParse("3"),
+			})
+		})
+
 		It("does not mark a device as shared when ConsumedCapacity is nil (exclusive allocation)", func() {
 			claim := withReservedFor(
 				resourceClaim("claim-a", deviceResult("device-0")),
@@ -823,6 +870,7 @@ var _ = Describe("DeviceAllocation Controller", func() {
 			meta := devices[deviceID("device-0")]
 			Expect(meta.Shared).To(BeFalse())
 			Expect(meta.ConsumedCapacity).To(BeNil())
+			Expect(meta.Contributions).To(BeEmpty())
 		})
 
 		It("handles a mix of shared and exclusive devices in the same claim", func() {

--- a/pkg/controllers/nodeclaim/disruption/suite_test.go
+++ b/pkg/controllers/nodeclaim/disruption/suite_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -69,13 +68,12 @@ var _ = BeforeEach(func() {
 		corev1.ResourceCPU:    resource.MustParse("100"),
 		corev1.ResourceMemory: resource.MustParse("100Gi"),
 	}
-	it = fake.NewInstanceType(fake.InstanceTypeOptions{
-		Name:             test.RandomName(),
-		Architecture:     "arch",
-		Resources:        resources,
-		OperatingSystems: sets.New(string(corev1.Linux)),
-		Offerings: []*cloudprovider.Offering{
-			{
+	it = fake.NewInstanceType(test.RandomName(),
+		fake.WithArchitecture("arch"),
+		fake.WithResources(resources),
+		fake.WithOperatingSystems(string(corev1.Linux)),
+		fake.WithOfferings(
+			cloudprovider.Offering{
 				Available: true,
 				Requirements: scheduling.NewLabelRequirements(map[string]string{
 					v1.CapacityTypeLabelKey:  v1.CapacityTypeSpot,
@@ -83,7 +81,7 @@ var _ = BeforeEach(func() {
 				}),
 				Price: fake.PriceFromResources(resources),
 			},
-			{
+			cloudprovider.Offering{
 				Available: true,
 				Requirements: scheduling.NewLabelRequirements(map[string]string{
 					v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
@@ -91,8 +89,8 @@ var _ = BeforeEach(func() {
 				}),
 				Price: fake.PriceFromResources(resources),
 			},
-		},
-	})
+		),
+	)
 	cp.InstanceTypes = append(cp.InstanceTypes, it)
 	ctx = options.ToContext(ctx, test.Options())
 	env.Clock.SetTime(time.Now())

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/multierr"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/workqueue"
@@ -49,6 +50,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	"sigs.k8s.io/karpenter/pkg/utils/result"
@@ -95,13 +97,22 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 	// higher concurrency limit since we want fast reaction to node syncing and launch
 	maxConcurrentReconciles := utilscontroller.LinearScaleReconciles(utilscontroller.CPUCount(ctx), minReconciles, maxReconciles)
 	qps, bucketSize := utilscontroller.GetTypedBucketConfigs(10, minReconciles, maxConcurrentReconciles)
-	return controllerruntime.NewControllerManagedBy(m).
+	b := controllerruntime.NewControllerManagedBy(m).
 		Named(c.Name()).
 		For(&v1.NodeClaim{}, builder.WithPredicates(nodeclaimutils.IsManagedPredicateFuncs(c.cloudProvider))).
 		Watches(
 			&corev1.Node{},
 			nodeclaimutils.NodeEventHandler(c.kubeClient, c.cloudProvider),
-		).
+		)
+	// When DRA is enabled, watch ResourceSlices so a NodeClaim is re-evaluated for initialization as its DRA drivers
+	// publish their pools. The watch (and its resource.k8s.io RBAC) is only wired up when DRA support is on.
+	if !options.FromContext(ctx).IgnoreDRARequests {
+		b = b.Watches(
+			&resourcev1.ResourceSlice{},
+			nodeclaimutils.ResourceSliceEventHandler(c.kubeClient, c.cloudProvider),
+		)
+	}
+	return b.
 		WithOptions(controller.Options{
 			RateLimiter: workqueue.NewTypedMaxOfRateLimiter[reconcile.Request](
 				// back off until last attempt occurs ~90 seconds before nodeclaim expiration

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -146,7 +146,7 @@ func RequestedResourcesRegistered(node *corev1.Node, nodeClaim *v1.NodeClaim) (c
 }
 
 // draDriverPoolsPublished reports whether the NodeClaim's expected DRA drivers have all published a complete pool for
-// the node. When DRA is disabled or the NodeClaim has no dra-drivers annotation, it is a no-op and returns ("", true,
+// the node. When DRA is disabled or the NodeClaim has no requested-dra-drivers annotation, it is a no-op and returns ("", true,
 // nil). Otherwise it lists the node's ResourceSlices and returns the first driver missing a complete pool (with ok
 // false), or ("", true, nil) when all expected drivers are satisfied.
 func (i *Initialization) draDriverPoolsPublished(ctx context.Context, node *corev1.Node, nodeClaim *v1.NodeClaim) (string, bool, error) {
@@ -196,9 +196,9 @@ func sliceBelongsToNode(slice *resourcev1.ResourceSlice, nodeName string) bool {
 	return false
 }
 
-// DRADriversPublished checks whether every DRA driver recorded in the NodeClaim's dra-drivers annotation has published
+// DRADriversPublished checks whether every DRA driver recorded in the NodeClaim's requested-dra-drivers annotation has published
 // at least one complete ResourceSlice pool among the node's slices. It returns the name of the first driver missing a
-// complete pool and false, or ("", true) when all expected drivers are satisfied. A NodeClaim with no dra-drivers
+// complete pool and false, or ("", true) when all expected drivers are satisfied. A NodeClaim with no requested-dra-drivers
 // annotation (or an empty value) is treated as having no expectation, so it returns ("", true).
 //
 // A pool is complete when the number of observed slices at the pool's highest generation equals the slices'

--- a/pkg/controllers/nodeclaim/lifecycle/initialization.go
+++ b/pkg/controllers/nodeclaim/lifecycle/initialization.go
@@ -19,17 +19,21 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
@@ -45,7 +49,10 @@ type Initialization struct {
 // a) its current status is set to Ready
 // b) all the startup taints have been removed from the node
 // c) all extended resources have been registered
+// d) all expected DRA drivers have published a complete resource pool (when DRA is enabled)
 // This method handles both nil nodepools and nodes without extended resources gracefully.
+//
+//nolint:gocyclo
 func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
 	if cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized); !cond.IsUnknown() {
 		// Ensure that we always set the status condition to the latest generation
@@ -74,6 +81,12 @@ func (i *Initialization) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim)
 	}
 	if name, ok := RequestedResourcesRegistered(node, nodeClaim); !ok {
 		nodeClaim.StatusConditions(status.WithClock(i.clock)).SetUnknownWithReason(v1.ConditionTypeInitialized, "ResourceNotRegistered", fmt.Sprintf("Resource %q was requested but not registered", name))
+		return reconcile.Result{}, nil
+	}
+	if driver, ok, err := i.draDriverPoolsPublished(ctx, node, nodeClaim); err != nil {
+		return reconcile.Result{}, err
+	} else if !ok {
+		nodeClaim.StatusConditions(status.WithClock(i.clock)).SetUnknownWithReason(v1.ConditionTypeInitialized, "DRADriverPoolsNotPublished", fmt.Sprintf("DRA driver %q has not published a complete resource pool", driver))
 		return reconcile.Result{}, nil
 	}
 	stored := node.DeepCopy()
@@ -130,6 +143,123 @@ func RequestedResourcesRegistered(node *corev1.Node, nodeClaim *v1.NodeClaim) (c
 		}
 	}
 	return "", true
+}
+
+// draDriverPoolsPublished reports whether the NodeClaim's expected DRA drivers have all published a complete pool for
+// the node. When DRA is disabled or the NodeClaim has no dra-drivers annotation, it is a no-op and returns ("", true,
+// nil). Otherwise it lists the node's ResourceSlices and returns the first driver missing a complete pool (with ok
+// false), or ("", true, nil) when all expected drivers are satisfied.
+func (i *Initialization) draDriverPoolsPublished(ctx context.Context, node *corev1.Node, nodeClaim *v1.NodeClaim) (string, bool, error) {
+	if options.FromContext(ctx).IgnoreDRARequests {
+		return "", true, nil
+	}
+	if _, ok := nodeClaim.Annotations[v1.DRADriversAnnotationKey]; !ok {
+		return "", true, nil
+	}
+	slices, err := i.resourceSlicesForNode(ctx, node)
+	if err != nil {
+		return "", false, err
+	}
+	driver, ok := DRADriversPublished(nodeClaim, slices)
+	return driver, ok, nil
+}
+
+// resourceSlicesForNode lists the ResourceSlices belonging to the given node. A slice belongs to the node when it pins
+// itself via spec.nodeName or carries a Node owner reference naming the node — the two forms node-local DRA drivers
+// use. Cluster-wide (AllNodes) slices are not node-owned and are intentionally excluded.
+func (i *Initialization) resourceSlicesForNode(ctx context.Context, node *corev1.Node) ([]resourcev1.ResourceSlice, error) {
+	sliceList := &resourcev1.ResourceSliceList{}
+	if err := i.kubeClient.List(ctx, sliceList); err != nil {
+		return nil, fmt.Errorf("listing resourceslices, %w", err)
+	}
+	var slices []resourcev1.ResourceSlice
+	for i := range sliceList.Items {
+		slice := &sliceList.Items[i]
+		if sliceBelongsToNode(slice, node.Name) {
+			slices = append(slices, *slice)
+		}
+	}
+	return slices, nil
+}
+
+// sliceBelongsToNode reports whether a ResourceSlice is local to the named node, via spec.nodeName or a Node owner
+// reference.
+func sliceBelongsToNode(slice *resourcev1.ResourceSlice, nodeName string) bool {
+	if lo.FromPtr(slice.Spec.NodeName) == nodeName {
+		return true
+	}
+	for _, ref := range slice.OwnerReferences {
+		if ref.Kind == "Node" && ref.Name == nodeName {
+			return true
+		}
+	}
+	return false
+}
+
+// DRADriversPublished checks whether every DRA driver recorded in the NodeClaim's dra-drivers annotation has published
+// at least one complete ResourceSlice pool among the node's slices. It returns the name of the first driver missing a
+// complete pool and false, or ("", true) when all expected drivers are satisfied. A NodeClaim with no dra-drivers
+// annotation (or an empty value) is treated as having no expectation, so it returns ("", true).
+//
+// A pool is complete when the number of observed slices at the pool's highest generation equals the slices'
+// declared ResourceSliceCount. This mirrors the allocator's pool-completeness notion (see Pool.Incomplete in
+// pkg/scheduling/dynamicresources/pool.go) without taking on that package's dependencies.
+func DRADriversPublished(nodeClaim *v1.NodeClaim, slices []resourcev1.ResourceSlice) (string, bool) {
+	annotation := strings.TrimSpace(nodeClaim.Annotations[v1.DRADriversAnnotationKey])
+	if annotation == "" {
+		return "", true
+	}
+	driversWithCompletePool := completePoolDrivers(slices)
+	for _, driver := range strings.Split(annotation, ",") {
+		driver = strings.TrimSpace(driver)
+		if driver == "" {
+			continue
+		}
+		if !driversWithCompletePool.Has(driver) {
+			return driver, false
+		}
+	}
+	return "", true
+}
+
+// completePoolDrivers returns the set of driver names that have at least one complete pool among the given slices. A
+// pool is complete when the number of observed slices at its highest generation equals their declared
+// ResourceSliceCount.
+func completePoolDrivers(slices []resourcev1.ResourceSlice) sets.Set[string] {
+	type poolKey struct{ driver, pool string }
+	// Track, per (driver, pool), the highest generation seen and the observed/declared slice counts at that generation.
+	type poolObservation struct {
+		generation         int64
+		resourceSliceCount int64
+		observed           int64
+	}
+	pools := map[poolKey]*poolObservation{}
+	for i := range slices {
+		s := &slices[i]
+		key := poolKey{driver: s.Spec.Driver, pool: s.Spec.Pool.Name}
+		gen := s.Spec.Pool.Generation
+		obs, ok := pools[key]
+		if !ok {
+			pools[key] = &poolObservation{generation: gen, resourceSliceCount: s.Spec.Pool.ResourceSliceCount, observed: 1}
+			continue
+		}
+		switch {
+		case gen > obs.generation:
+			// A newer generation supersedes older slices — reset the observation to this generation.
+			obs.generation = gen
+			obs.resourceSliceCount = s.Spec.Pool.ResourceSliceCount
+			obs.observed = 1
+		case gen == obs.generation:
+			obs.observed++
+		}
+	}
+	drivers := sets.New[string]()
+	for key, obs := range pools {
+		if obs.resourceSliceCount > 0 && obs.observed == obs.resourceSliceCount {
+			drivers.Insert(key.driver)
+		}
+	}
+	return drivers
 }
 
 func formatTaint(taint *corev1.Taint) string {

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -18,6 +18,8 @@ package lifecycle_test
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -248,5 +251,137 @@ var _ = Describe("Finalizer", func() {
 
 		Expect(nodeClaim.StatusConditions().Get(status.ConditionReady).IsTrue()).To(BeTrue())
 		Expect(nodeClaim.StatusConditions().Get(status.ConditionReady).ObservedGeneration).To(Equal(nodeClaim.Generation))
+	})
+})
+
+var _ = Describe("DRA Initialization Gating", func() {
+	var nodePool *v1.NodePool
+
+	const (
+		driverA = "driver-a.example.com"
+		driverB = "driver-b.example.com"
+	)
+
+	BeforeEach(func() {
+		// Enable DRA so the initialization gate is active.
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{IgnoreDRARequests: lo.ToPtr(false)}))
+		nodePool = test.NodePool()
+	})
+
+	AfterEach(func() {
+		// ResourceSlices are cluster-scoped and not handled by ExpectCleanedUp; remove them between tests.
+		Expect(env.Client.DeleteAllOf(ctx, &resourcev1.ResourceSlice{})).To(Succeed())
+	})
+
+	// registeredReadyNodeClaim creates a NodeClaim with the given dra-drivers annotation, drives it through launch and
+	// registration, and returns the NodeClaim and its Ready node. At this point the only thing blocking initialization
+	// is the DRA gate (node is Ready, registered, no taints, and requests no extended resources).
+	registeredReadyNodeClaim := func(drivers string) (*v1.NodeClaim, *corev1.Node) {
+		GinkgoHelper()
+		ncOpts := v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name}}}
+		if drivers != "" {
+			ncOpts.Annotations = map[string]string{v1.DRADriversAnnotationKey: drivers}
+		}
+		nodeClaim := test.NodeClaim(ncOpts)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+
+		node := test.Node(test.NodeOptions{
+			ProviderID: nodeClaim.Status.ProviderID,
+			Taints:     []corev1.Taint{v1.UnregisteredNoExecuteTaint},
+		})
+		ExpectApplied(ctx, env.Client, node)
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		ExpectMakeNodesReady(ctx, env.Client, env.Clock, node)
+		return nodeClaim, ExpectExists(ctx, env.Client, node)
+	}
+
+	// nodeSlice builds a ResourceSlice pinned to the node, declaring a pool with the given driver, pool name, generation,
+	// total slice count, and a single device. Apply `count` of these (incrementing the device name) to complete a pool.
+	nodeSlice := func(node *corev1.Node, driver, pool string, generation, count int64, device string) *resourcev1.ResourceSlice {
+		return test.ResourceSlice(resourcev1.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("%s-%s-%s", node.Name, pool, device),
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Node", Name: node.Name, UID: node.UID}},
+			},
+			Spec: resourcev1.ResourceSliceSpec{
+				Driver:   driver,
+				NodeName: lo.ToPtr(node.Name),
+				Pool:     resourcev1.ResourcePool{Name: pool, Generation: generation, ResourceSliceCount: count},
+				Devices:  []resourcev1.Device{{Name: device}},
+			},
+		})
+	}
+	reconcile := func(nodeClaim *v1.NodeClaim) *v1.NodeClaim {
+		GinkgoHelper()
+		ExpectObjectReconciled(ctx, env.Client, nodeClaimController, nodeClaim)
+		return ExpectExists(ctx, env.Client, nodeClaim)
+	}
+
+	It("holds initialization until the expected driver publishes a complete pool (a)", func() {
+		nodeClaim, node := registeredReadyNodeClaim(driverA)
+
+		nodeClaim = reconcile(nodeClaim)
+		cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized)
+		Expect(cond.IsUnknown()).To(BeTrue())
+		Expect(cond.Reason).To(Equal("DRADriverPoolsNotPublished"))
+
+		ExpectApplied(ctx, env.Client, nodeSlice(node, driverA, "pool-a", 1, 1, "dev-0"))
+		nodeClaim = reconcile(nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
+	})
+
+	It("does not consider an incomplete pool satisfied (b)", func() {
+		nodeClaim, node := registeredReadyNodeClaim(driverA)
+
+		// Pool declares 2 slices but only 1 is published.
+		ExpectApplied(ctx, env.Client, nodeSlice(node, driverA, "pool-a", 1, 2, "dev-0"))
+		nodeClaim = reconcile(nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsUnknown()).To(BeTrue())
+
+		// Publishing the second slice completes the pool.
+		ExpectApplied(ctx, env.Client, nodeSlice(node, driverA, "pool-a", 1, 2, "dev-1"))
+		nodeClaim = reconcile(nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
+	})
+
+	It("does not let stale older-generation slices satisfy a newer incomplete pool (b2)", func() {
+		nodeClaim, node := registeredReadyNodeClaim(driverA)
+
+		// Generation 1 was complete (count 1), but generation 2 now declares 2 slices with only 1 published.
+		ExpectApplied(ctx, env.Client, nodeSlice(node, driverA, "pool-a", 2, 2, "dev-0"))
+		nodeClaim = reconcile(nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsUnknown()).To(BeTrue())
+	})
+
+	It("requires every expected driver to publish a complete pool (c)", func() {
+		nodeClaim, node := registeredReadyNodeClaim(strings.Join([]string{driverA, driverB}, ","))
+
+		// Only driverA has a complete pool.
+		ExpectApplied(ctx, env.Client, nodeSlice(node, driverA, "pool-a", 1, 1, "dev-0"))
+		nodeClaim = reconcile(nodeClaim)
+		cond := nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized)
+		Expect(cond.IsUnknown()).To(BeTrue())
+		Expect(cond.Message).To(ContainSubstring(driverB))
+
+		// Publish driverB's pool — now both are satisfied.
+		ExpectApplied(ctx, env.Client, nodeSlice(node, driverB, "pool-b", 1, 1, "dev-0"))
+		nodeClaim = reconcile(nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
+	})
+
+	It("initializes a NodeClaim with no dra-drivers annotation (d)", func() {
+		nodeClaim, _ := registeredReadyNodeClaim("")
+		nodeClaim = reconcile(nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
+	})
+
+	It("skips the gate when DRA is disabled (e)", func() {
+		// Even with an annotation and no published slices, a DRA-disabled cluster initializes normally.
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{IgnoreDRARequests: lo.ToPtr(true)}))
+		nodeClaim, _ := registeredReadyNodeClaim(driverA)
+		nodeClaim = reconcile(nodeClaim)
+		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
 	})
 })

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -273,7 +273,7 @@ var _ = Describe("DRA Initialization Gating", func() {
 		Expect(env.Client.DeleteAllOf(ctx, &resourcev1.ResourceSlice{})).To(Succeed())
 	})
 
-	// registeredReadyNodeClaim creates a NodeClaim with the given dra-drivers annotation, drives it through launch and
+	// registeredReadyNodeClaim creates a NodeClaim with the given requested-dra-drivers annotation, drives it through launch and
 	// registration, and returns the NodeClaim and its Ready node. At this point the only thing blocking initialization
 	// is the DRA gate (node is Ready, registered, no taints, and requests no extended resources).
 	registeredReadyNodeClaim := func(drivers string) (*v1.NodeClaim, *corev1.Node) {
@@ -371,7 +371,7 @@ var _ = Describe("DRA Initialization Gating", func() {
 		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())
 	})
 
-	It("initializes a NodeClaim with no dra-drivers annotation (d)", func() {
+	It("initializes a NodeClaim with no requested-dra-drivers annotation (d)", func() {
 		nodeClaim, _ := registeredReadyNodeClaim("")
 		nodeClaim = reconcile(nodeClaim)
 		Expect(nodeClaim.StatusConditions().Get(v1.ConditionTypeInitialized).IsTrue()).To(BeTrue())

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -263,13 +263,22 @@ var _ = Describe("DRA Initialization Gating", func() {
 	)
 
 	BeforeEach(func() {
+		// The DRA initialization gate relies on the resource.k8s.io/v1 ResourceSlice API, which only exists on k8s
+		// >= 1.34. Skip below that — there is no DRA to gate on.
+		if env.Version.Minor() < 34 {
+			Skip("DRA is only available in K8s versions >= 1.34.x")
+		}
 		// Enable DRA so the initialization gate is active.
 		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{IgnoreDRARequests: lo.ToPtr(false)}))
 		nodePool = test.NodePool()
 	})
 
 	AfterEach(func() {
-		// ResourceSlices are cluster-scoped and not handled by ExpectCleanedUp; remove them between tests.
+		// ResourceSlices are cluster-scoped and not handled by ExpectCleanedUp; remove them between tests. Guard on the
+		// version since the ResourceSlice API (and thus DeleteAllOf) isn't served before 1.34.
+		if env.Version.Minor() < 34 {
+			return
+		}
 		Expect(env.Client.DeleteAllOf(ctx, &resourcev1.ResourceSlice{})).To(Succeed())
 	})
 

--- a/pkg/controllers/nodeoverlay/store_bench_test.go
+++ b/pkg/controllers/nodeoverlay/store_bench_test.go
@@ -40,13 +40,12 @@ func BenchmarkStoreApply(b *testing.B) {
 	for _, family := range families {
 		for _, size := range sizes {
 			name := family + "." + size
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: name,
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType(name,
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("16Gi"),
-				},
-			}))
+				}),
+			))
 		}
 	}
 
@@ -91,9 +90,7 @@ func BenchmarkStoreApply(b *testing.B) {
 func BenchmarkStoreApplyNoOverlay(b *testing.B) {
 	instanceTypes := make([]*cloudprovider.InstanceType, 0, 200)
 	for range 200 {
-		instanceTypes = append(instanceTypes, fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "m5.large",
-		}))
+		instanceTypes = append(instanceTypes, fake.NewInstanceType("m5.large"))
 	}
 
 	store := newInternalInstanceTypeStore()
@@ -113,9 +110,7 @@ func BenchmarkStoreApplyNoOverlay(b *testing.B) {
 func BenchmarkStoreApplyPriceOnly(b *testing.B) {
 	instanceTypes := make([]*cloudprovider.InstanceType, 0, 200)
 	for range 200 {
-		instanceTypes = append(instanceTypes, fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "m5.large",
-		}))
+		instanceTypes = append(instanceTypes, fake.NewInstanceType("m5.large"))
 	}
 
 	store := newInternalInstanceTypeStore()
@@ -149,9 +144,7 @@ func BenchmarkStoreApplyPriceOnly(b *testing.B) {
 func BenchmarkStoreApplyCapacityOnly(b *testing.B) {
 	instanceTypes := make([]*cloudprovider.InstanceType, 0, 200)
 	for range 200 {
-		instanceTypes = append(instanceTypes, fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "m5.large",
-		}))
+		instanceTypes = append(instanceTypes, fake.NewInstanceType("m5.large"))
 	}
 
 	store := newInternalInstanceTypeStore()
@@ -182,9 +175,7 @@ func BenchmarkStoreApplyCapacityOnly(b *testing.B) {
 func BenchmarkStoreApplyBothOverlays(b *testing.B) {
 	instanceTypes := make([]*cloudprovider.InstanceType, 0, 200)
 	for range 200 {
-		instanceTypes = append(instanceTypes, fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "m5.large",
-		}))
+		instanceTypes = append(instanceTypes, fake.NewInstanceType("m5.large"))
 	}
 
 	store := newInternalInstanceTypeStore()
@@ -229,9 +220,7 @@ func BenchmarkStoreApplyAllScenario(b *testing.B) {
 		for _, size := range sizes {
 			for range 5 { // Create multiple instances to reach ~200
 				name := family + "." + size
-				instanceTypes = append(instanceTypes, fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: name,
-				}))
+				instanceTypes = append(instanceTypes, fake.NewInstanceType(name))
 			}
 		}
 	}
@@ -322,9 +311,7 @@ func BenchmarkNodeOverlayControllerScenario(b *testing.B) {
 		for _, size := range sizes {
 			for range 4 { // ~216 instance types total
 				name := family + "." + size
-				instanceTypes = append(instanceTypes, fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: name,
-				}))
+				instanceTypes = append(instanceTypes, fake.NewInstanceType(name))
 			}
 		}
 	}

--- a/pkg/controllers/nodeoverlay/store_memory_test.go
+++ b/pkg/controllers/nodeoverlay/store_memory_test.go
@@ -353,13 +353,12 @@ func createRealisticInstanceTypes(count int) []*cloudprovider.InstanceType {
 			cpuValue := 2 * (idx%8 + 1)
 			memoryValue := 4 * (idx%8 + 1)
 
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: name,
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType(name,
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", cpuValue)),
 					corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", memoryValue)),
-				},
-			}))
+				}),
+			))
 			idx++
 		}
 		if idx >= count {

--- a/pkg/controllers/nodeoverlay/store_test.go
+++ b/pkg/controllers/nodeoverlay/store_test.go
@@ -80,19 +80,16 @@ var _ = Describe("Store Apply Selective Copy", func() {
 		},
 		Entry("no overlays - everything shared",
 			"no overlays - everything shared",
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "m5.large",
-				Offerings: []*cloudprovider.Offering{
-					{
-						Requirements: scheduling.NewRequirements(
-							scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
-							scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
-						),
-						Price:     0.096,
-						Available: true,
-					},
-				},
-			}),
+			fake.NewInstanceType("m5.large",
+				fake.WithOfferings(cloudprovider.Offering{
+					Requirements: scheduling.NewRequirements(
+						scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
+						scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
+					),
+					Price:     0.096,
+					Available: true,
+				}),
+			),
 			nil,
 			&capacityUpdate{OverlayUpdate: corev1.ResourceList{}},
 			true, // expectSharedReqs
@@ -103,14 +100,10 @@ var _ = Describe("Store Apply Selective Copy", func() {
 		Entry("price overlay only - offerings copied, others shared",
 			"price overlay only - offerings copied, others shared",
 			func() *cloudprovider.InstanceType {
-				return fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "m5.large",
-				})
+				return fake.NewInstanceType("m5.large")
 			}(),
 			func() map[string]*priceUpdate {
-				it := fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "m5.large",
-				})
+				it := fake.NewInstanceType("m5.large")
 				// Use actual requirements string from the generated instance type
 				return map[string]*priceUpdate{
 					it.Offerings[0].Requirements.String(): {OverlayUpdate: new("+0.01"), lowestWeight: new(int32(10))},
@@ -124,19 +117,16 @@ var _ = Describe("Store Apply Selective Copy", func() {
 		),
 		Entry("capacity overlay only - capacity copied, others shared",
 			"capacity overlay only - capacity copied, others shared",
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "m5.large",
-				Offerings: []*cloudprovider.Offering{
-					{
-						Requirements: scheduling.NewRequirements(
-							scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
-							scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
-						),
-						Price:     0.096,
-						Available: true,
-					},
-				},
-			}),
+			fake.NewInstanceType("m5.large",
+				fake.WithOfferings(cloudprovider.Offering{
+					Requirements: scheduling.NewRequirements(
+						scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
+						scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
+					),
+					Price:     0.096,
+					Available: true,
+				}),
+			),
 			nil,
 			&capacityUpdate{
 				OverlayUpdate: corev1.ResourceList{
@@ -151,14 +141,10 @@ var _ = Describe("Store Apply Selective Copy", func() {
 		Entry("both overlays - only modified fields copied",
 			"both overlays - only modified fields copied",
 			func() *cloudprovider.InstanceType {
-				return fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "m5.large",
-				})
+				return fake.NewInstanceType("m5.large")
 			}(),
 			func() map[string]*priceUpdate {
-				it := fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "m5.large",
-				})
+				it := fake.NewInstanceType("m5.large")
 				return map[string]*priceUpdate{
 					it.Offerings[0].Requirements.String(): {OverlayUpdate: new("+0.01"), lowestWeight: new(int32(10))},
 				}
@@ -180,10 +166,9 @@ var _ = Describe("Store Apply Correctness", func() {
 	Context("with price overlay", func() {
 		It("should correctly apply price overlay to specific offerings", func() {
 			originalPrice := 0.096
-			instanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "m5.large",
-				Offerings: []*cloudprovider.Offering{
-					{
+			instanceType := fake.NewInstanceType("m5.large",
+				fake.WithOfferings(
+					cloudprovider.Offering{
 						Requirements: scheduling.NewRequirements(
 							scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 							scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
@@ -191,7 +176,7 @@ var _ = Describe("Store Apply Correctness", func() {
 						Price:     originalPrice,
 						Available: true,
 					},
-					{
+					cloudprovider.Offering{
 						Requirements: scheduling.NewRequirements(
 							scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2b"),
 							scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
@@ -199,8 +184,8 @@ var _ = Describe("Store Apply Correctness", func() {
 						Price:     originalPrice,
 						Available: true,
 					},
-				},
-			})
+				),
+			)
 
 			store := newInternalInstanceTypeStore()
 			store.evaluatedNodePools.Insert("default")
@@ -234,13 +219,12 @@ var _ = Describe("Store Apply Correctness", func() {
 	Context("with capacity overlay", func() {
 		It("should correctly apply capacity overlay", func() {
 			originalMemory := resource.MustParse("8Gi")
-			instanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "m5.large",
-				Resources: corev1.ResourceList{
+			instanceType := fake.NewInstanceType("m5.large",
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceMemory: originalMemory,
 					corev1.ResourceCPU:    resource.MustParse("2"),
-				},
-			})
+				}),
+			)
 
 			store := newInternalInstanceTypeStore()
 			store.evaluatedNodePools.Insert("default")
@@ -276,19 +260,16 @@ var _ = Describe("Store Apply Correctness", func() {
 
 var _ = Describe("Store Apply Isolation Between NodePools", func() {
 	It("should apply different overlays to different node pools", func() {
-		instanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "m5.large",
-			Offerings: []*cloudprovider.Offering{
-				{
-					Requirements: scheduling.NewRequirements(
-						scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
-						scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
-					),
-					Price:     0.096,
-					Available: true,
-				},
-			},
-		})
+		instanceType := fake.NewInstanceType("m5.large",
+			fake.WithOfferings(cloudprovider.Offering{
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
+					scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
+				),
+				Price:     0.096,
+				Available: true,
+			}),
+		)
 
 		store := newInternalInstanceTypeStore()
 		store.evaluatedNodePools.Insert("nodepool-a", "nodepool-b")
@@ -338,9 +319,7 @@ var _ = Describe("Store Apply Isolation Between NodePools", func() {
 
 var _ = Describe("Store Apply Unevaluated NodePool", func() {
 	It("should return error for unevaluated node pool", func() {
-		instanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "m5.large",
-		})
+		instanceType := fake.NewInstanceType("m5.large")
 
 		publicStore := NewInstanceTypeStore()
 		store := newInternalInstanceTypeStore()
@@ -359,10 +338,9 @@ var _ = Describe("NodeOverlay Store Integration", func() {
 	It("should integrate overlays through the public interface", func() {
 		// Create a realistic scenario with multiple instance types and overlays
 		instanceTypes := []*cloudprovider.InstanceType{
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "m5.large",
-				Offerings: []*cloudprovider.Offering{
-					{
+			fake.NewInstanceType("m5.large",
+				fake.WithOfferings(
+					cloudprovider.Offering{
 						Requirements: scheduling.NewRequirements(
 							scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 							scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
@@ -370,7 +348,7 @@ var _ = Describe("NodeOverlay Store Integration", func() {
 						Price:     0.096,
 						Available: true,
 					},
-					{
+					cloudprovider.Offering{
 						Requirements: scheduling.NewRequirements(
 							scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 							scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "spot"),
@@ -378,29 +356,26 @@ var _ = Describe("NodeOverlay Store Integration", func() {
 						Price:     0.0288,
 						Available: true,
 					},
-				},
-				Resources: corev1.ResourceList{
+				),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("8Gi"),
 					corev1.ResourceCPU:    resource.MustParse("2"),
-				},
-			}),
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "m5.xlarge",
-				Offerings: []*cloudprovider.Offering{
-					{
-						Requirements: scheduling.NewRequirements(
-							scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
-							scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
-						),
-						Price:     0.192,
-						Available: true,
-					},
-				},
-				Resources: corev1.ResourceList{
+				}),
+			),
+			fake.NewInstanceType("m5.xlarge",
+				fake.WithOfferings(cloudprovider.Offering{
+					Requirements: scheduling.NewRequirements(
+						scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
+						scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, "on-demand"),
+					),
+					Price:     0.192,
+					Available: true,
+				}),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("16Gi"),
 					corev1.ResourceCPU:    resource.MustParse("4"),
-				},
-			}),
+				}),
+			),
 		}
 
 		publicStore := NewInstanceTypeStore()

--- a/pkg/controllers/nodeoverlay/suite_test.go
+++ b/pkg/controllers/nodeoverlay/suite_test.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -80,19 +79,16 @@ var _ = BeforeEach(func() {
 	store.Reset()
 
 	cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-		fake.NewInstanceType(fake.InstanceTypeOptions{
-			Name: "default-instance-type",
-			Offerings: []*cloudprovider.Offering{
-				{
-					Available: true,
-					Requirements: scheduling.NewLabelRequirements(map[string]string{
-						v1.CapacityTypeLabelKey:  "spot",
-						corev1.LabelTopologyZone: "test-zone-1",
-					}),
-					Price: 1.020,
-				},
-			},
-		}),
+		fake.NewInstanceType("default-instance-type",
+			fake.WithOfferings(cloudprovider.Offering{
+				Available: true,
+				Requirements: scheduling.NewLabelRequirements(map[string]string{
+					v1.CapacityTypeLabelKey:  "spot",
+					corev1.LabelTopologyZone: "test-zone-1",
+				}),
+				Price: 1.020,
+			}),
+		),
 	}
 	ExpectApplied(ctx, env.Client, nodePool)
 })
@@ -237,16 +233,14 @@ var _ = Describe("Validation", func() {
 			})
 			It("should succeed with requirements overlays don't overlap", func() {
 				cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name:             "arm-instance-type",
-						Architecture:     "arm64",
-						OperatingSystems: sets.New(string(corev1.Linux), string(corev1.Windows), "darwin"),
-					}),
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name:             "amd-instance-type",
-						Architecture:     "amd64",
-						OperatingSystems: sets.New("ios"),
-					}),
+					fake.NewInstanceType("arm-instance-type",
+						fake.WithArchitecture("arm64"),
+						fake.WithOperatingSystems(string(corev1.Linux), string(corev1.Windows), "darwin"),
+					),
+					fake.NewInstanceType("amd-instance-type",
+						fake.WithArchitecture("amd64"),
+						fake.WithOperatingSystems("ios"),
+					),
 				}
 				overlayA := test.NodeOverlay(v1alpha1.NodeOverlay{
 					ObjectMeta: metav1.ObjectMeta{
@@ -296,10 +290,9 @@ var _ = Describe("Validation", func() {
 		Describe("Offering Requirements", func() {
 			BeforeEach(func() {
 				cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name: "default-instance-type",
-						Offerings: []*cloudprovider.Offering{
-							{
+					fake.NewInstanceType("default-instance-type",
+						fake.WithOfferings(
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "spot",
@@ -307,7 +300,7 @@ var _ = Describe("Validation", func() {
 								}),
 								Price: 1.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "on-demand",
@@ -315,7 +308,7 @@ var _ = Describe("Validation", func() {
 								}),
 								Price: 2.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "spot",
@@ -323,7 +316,7 @@ var _ = Describe("Validation", func() {
 								}),
 								Price: 3.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "reserved",
@@ -331,8 +324,8 @@ var _ = Describe("Validation", func() {
 								}),
 								Price: 4.020,
 							},
-						},
-					}),
+						),
+					),
 				}
 			})
 			It("should fail with requirements overlays overlap on zone", func() {
@@ -1291,10 +1284,9 @@ var _ = Describe("Instance Type Controller", func() {
 		DescribeTable("should apply pricing updates for instances types for capacity type",
 			func(changesOverlay v1alpha1.NodeOverlay, expectedValue float64) {
 				cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name: "default-instance-type",
-						Offerings: []*cloudprovider.Offering{
-							{
+					fake.NewInstanceType("default-instance-type",
+						fake.WithOfferings(
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "spot",
@@ -1302,7 +1294,7 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 1.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "on-demand",
@@ -1310,8 +1302,8 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 5.020,
 							},
-						},
-					}),
+						),
+					),
 				}
 				overlay := test.NodeOverlay(v1alpha1.NodeOverlay{
 					Spec: v1alpha1.NodeOverlaySpec{
@@ -1357,10 +1349,9 @@ var _ = Describe("Instance Type Controller", func() {
 		DescribeTable("should apply pricing updates for instances types for availability zone",
 			func(changesOverlay v1alpha1.NodeOverlay, expectedValue float64) {
 				cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name: "default-instance-type",
-						Offerings: []*cloudprovider.Offering{
-							{
+					fake.NewInstanceType("default-instance-type",
+						fake.WithOfferings(
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "spot",
@@ -1368,7 +1359,7 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 1.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "spot",
@@ -1376,8 +1367,8 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 5.020,
 							},
-						},
-					}),
+						),
+					),
 				}
 				overlay := test.NodeOverlay(v1alpha1.NodeOverlay{
 					Spec: v1alpha1.NodeOverlaySpec{
@@ -1423,10 +1414,9 @@ var _ = Describe("Instance Type Controller", func() {
 		DescribeTable("should update price updates offerings instance types from multiple overlays",
 			func(changesOverlayA v1alpha1.NodeOverlay, changesOverlayB v1alpha1.NodeOverlay, expectedValueOne float64, expectedValueTwo float64, expectedValueThree float64) {
 				cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name: "default-instance-type",
-						Offerings: []*cloudprovider.Offering{
-							{
+					fake.NewInstanceType("default-instance-type",
+						fake.WithOfferings(
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "spot",
@@ -1434,7 +1424,7 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 1.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "on-demand",
@@ -1442,7 +1432,7 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 2.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "reserved",
@@ -1450,8 +1440,8 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 4.020,
 							},
-						},
-					}),
+						),
+					),
 				}
 				overlayA := test.NodeOverlay(v1alpha1.NodeOverlay{
 					Spec: v1alpha1.NodeOverlaySpec{
@@ -1530,10 +1520,9 @@ var _ = Describe("Instance Type Controller", func() {
 		DescribeTable("should update price updates offerings instance types from multiple overlays with different weights",
 			func(changesOverlayA v1alpha1.NodeOverlay, changesOverlayB v1alpha1.NodeOverlay, expectedValueOne float64, expectedValueTwo float64) {
 				cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-					fake.NewInstanceType(fake.InstanceTypeOptions{
-						Name: "default-instance-type",
-						Offerings: []*cloudprovider.Offering{
-							{
+					fake.NewInstanceType("default-instance-type",
+						fake.WithOfferings(
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "spot",
@@ -1541,7 +1530,7 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 1.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "on-demand",
@@ -1549,7 +1538,7 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 2.020,
 							},
-							{
+							cloudprovider.Offering{
 								Available: true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{
 									v1.CapacityTypeLabelKey:  "reserved",
@@ -1557,8 +1546,8 @@ var _ = Describe("Instance Type Controller", func() {
 								}),
 								Price: 4.020,
 							},
-						},
-					}),
+						),
+					),
 				}
 				overlayA := test.NodeOverlay(v1alpha1.NodeOverlay{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2039,45 +2028,36 @@ var _ = Describe("Instance Type Controller", func() {
 		})
 		It("should update capacity for instance types from multiple overlays", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "default-instance-type-zone-one",
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  "spot",
-								corev1.LabelTopologyZone: "test-zone-1",
-							}),
-							Price: 1.020,
-						},
-					},
-				}),
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "default-instance-type-zone-two",
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  "on-demand",
-								corev1.LabelTopologyZone: "test-zone-2",
-							}),
-							Price: 2.020,
-						},
-					},
-				}),
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "default-instance-type-zone-four",
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  "reserved",
-								corev1.LabelTopologyZone: "test-zone-4",
-							}),
-							Price: 4.020,
-						},
-					},
-				}),
+				fake.NewInstanceType("default-instance-type-zone-one",
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  "spot",
+							corev1.LabelTopologyZone: "test-zone-1",
+						}),
+						Price: 1.020,
+					}),
+				),
+				fake.NewInstanceType("default-instance-type-zone-two",
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  "on-demand",
+							corev1.LabelTopologyZone: "test-zone-2",
+						}),
+						Price: 2.020,
+					}),
+				),
+				fake.NewInstanceType("default-instance-type-zone-four",
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  "reserved",
+							corev1.LabelTopologyZone: "test-zone-4",
+						}),
+						Price: 4.020,
+					}),
+				),
 			}
 			overlayA := test.NodeOverlay(v1alpha1.NodeOverlay{
 				Spec: v1alpha1.NodeOverlaySpec{
@@ -2143,19 +2123,16 @@ var _ = Describe("Instance Type Controller", func() {
 		})
 		It("should update capacity for one instance types from multiple overlays", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "default-instance-type-zone-one",
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  "spot",
-								corev1.LabelTopologyZone: "test-zone-1",
-							}),
-							Price: 1.020,
-						},
-					},
-				}),
+				fake.NewInstanceType("default-instance-type-zone-one",
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  "spot",
+							corev1.LabelTopologyZone: "test-zone-1",
+						}),
+						Price: 1.020,
+					}),
+				),
 			}
 			overlayA := test.NodeOverlay(v1alpha1.NodeOverlay{
 				Spec: v1alpha1.NodeOverlaySpec{
@@ -2210,45 +2187,36 @@ var _ = Describe("Instance Type Controller", func() {
 		})
 		It("should update price offerings instance types from multiple overlays with different weights", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "default-instance-type-zone-one",
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  "spot",
-								corev1.LabelTopologyZone: "test-zone-1",
-							}),
-							Price: 1.020,
-						},
-					},
-				}),
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "default-instance-type-zone-two",
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  "on-demand",
-								corev1.LabelTopologyZone: "test-zone-2",
-							}),
-							Price: 2.020,
-						},
-					},
-				}),
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "default-instance-type-zone-four",
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  "reserved",
-								corev1.LabelTopologyZone: "test-zone-4",
-							}),
-							Price: 4.020,
-						},
-					},
-				}),
+				fake.NewInstanceType("default-instance-type-zone-one",
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  "spot",
+							corev1.LabelTopologyZone: "test-zone-1",
+						}),
+						Price: 1.020,
+					}),
+				),
+				fake.NewInstanceType("default-instance-type-zone-two",
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  "on-demand",
+							corev1.LabelTopologyZone: "test-zone-2",
+						}),
+						Price: 2.020,
+					}),
+				),
+				fake.NewInstanceType("default-instance-type-zone-four",
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: scheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  "reserved",
+							corev1.LabelTopologyZone: "test-zone-4",
+						}),
+						Price: 4.020,
+					}),
+				),
 			}
 			overlayA := test.NodeOverlay(v1alpha1.NodeOverlay{
 				Spec: v1alpha1.NodeOverlaySpec{

--- a/pkg/controllers/provisioning/dra.go
+++ b/pkg/controllers/provisioning/dra.go
@@ -1,0 +1,130 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	"context"
+	"fmt"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
+)
+
+// gatherResourceSlices lists the in-cluster ResourceSlices and filters them down to the set the DRA allocator should
+// treat as the published universe of in-cluster devices. A slice is dropped when it is owned by a Node that is not
+// represented by an initialized, included stateNode:
+//   - Slices owned by nodes that aren't in the provided stateNode set (deleting nodes, disruption candidates) are
+//     excluded, since those nodes' devices shouldn't be considered persistent capacity.
+//   - Slices owned by uninitialized nodes are excluded. Until a node is initialized its devices are represented by
+//     template devices (see the NodeClaim adapters), so including its published slices would double-count them.
+//
+// Ownership is determined via metadata.ownerReferences (Kind == "Node"), not spec.nodeName, which only indicates
+// accessibility. Slices with no Node owner reference (e.g. cluster-wide slices) are always included.
+func (p *Provisioner) gatherResourceSlices(ctx context.Context, stateNodes []*state.StateNode) ([]dynamicresources.ResourceSlice, error) {
+	sliceList := &resourcev1.ResourceSliceList{}
+	if err := p.kubeClient.List(ctx, sliceList); err != nil {
+		return nil, fmt.Errorf("listing resourceslices, %w", err)
+	}
+
+	includedNodeNames := sets.New[string]()
+	for _, n := range stateNodes {
+		if n.Node == nil {
+			continue
+		}
+		if n.Initialized() {
+			includedNodeNames.Insert(n.Name())
+		}
+	}
+
+	slices := make([]dynamicresources.ResourceSlice, 0, len(sliceList.Items))
+	for i := range sliceList.Items {
+		slice := &sliceList.Items[i]
+		if ownerNode, ok := nodeOwnerName(slice); ok && !includedNodeNames.Has(ownerNode) {
+			continue
+		}
+		slices = append(slices, dynamicresources.NewAPIServerSlice(slice))
+	}
+	return slices, nil
+}
+
+// nodeOwnerName returns the name of the Node that owns the ResourceSlice via an ownerReference, along with whether such
+// an owner reference exists. Slices published by node-local DRA drivers carry a Node owner reference; cluster-wide
+// slices may not.
+func nodeOwnerName(slice *resourcev1.ResourceSlice) (string, bool) {
+	for _, ref := range slice.OwnerReferences {
+		if ref.Kind == "Node" {
+			return ref.Name, true
+		}
+	}
+	return "", false
+}
+
+// gatherAllocatedDevices reads the set of in-cluster allocated devices from the deviceallocation controller and filters
+// out devices that should be treated as available for reallocation:
+//   - Devices allocated exclusively by deleting pods (all consumers are in deletingPodUIDs) are excluded, since those
+//     pods are migrating off their nodes.
+//   - Releasable devices with no live consumers (unowned) are excluded.
+//
+// The remaining devices form the allocator's immutable seed set of already-allocated in-cluster devices, split into
+// exclusively-allocated devices and the consumed capacity of multi-allocatable (shared) devices.
+func (p *Provisioner) gatherAllocatedDevices(ctx context.Context, deletingPodUIDs sets.Set[types.UID]) (dynamicresources.AllocatedDeviceState, error) {
+	seq, err := p.deviceAllocationController.AllocatedDevices(ctx)
+	if err != nil {
+		return dynamicresources.AllocatedDeviceState{}, fmt.Errorf("getting allocated devices, %w", err)
+	}
+	state := dynamicresources.AllocatedDeviceState{
+		ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
+		ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{},
+	}
+	for id, meta := range seq {
+		// A device with no live consumers that every referencing claim considers releasable is available.
+		if meta.Releasable && len(meta.PodUIDs) == 0 {
+			continue
+		}
+		// A device consumed only by deleting pods is available for reallocation.
+		if len(meta.PodUIDs) > 0 && allConsumersDeleting(meta.PodUIDs, deletingPodUIDs) {
+			continue
+		}
+		if meta.Shared {
+			// TODO(follow-up B1/B2): partial capacity subtraction for deleting pods. The exposed DeviceMetadata only
+			// carries the aggregated ConsumedCapacity across all claims, not the per-claim breakdown needed to free
+			// just the deleting pods' share of a shared device. Until the deviceallocation controller surfaces
+			// per-claim contributions, we pass the full aggregated capacity through unchanged. This is conservative:
+			// shared capacity held by deleting pods is not yet freed for reallocation (over-counts usage, never
+			// over-allocates).
+			state.ConsumedCapacity[id] = meta.ConsumedCapacity
+			continue
+		}
+		state.ExclusiveDevices.Insert(id)
+	}
+	return state, nil
+}
+
+func allConsumersDeleting(podUIDs []types.UID, deletingPodUIDs sets.Set[types.UID]) bool {
+	for _, uid := range podUIDs {
+		if !deletingPodUIDs.Has(uid) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/controllers/provisioning/dra.go
+++ b/pkg/controllers/provisioning/dra.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
 )
@@ -80,10 +81,13 @@ func nodeOwnerName(slice *resourcev1.ResourceSlice) (string, bool) {
 }
 
 // gatherAllocatedDevices reads the set of in-cluster allocated devices from the deviceallocation controller and filters
-// out devices that should be treated as available for reallocation:
+// out devices (or portions of shared-device capacity) that should be treated as available for reallocation:
 //   - Devices allocated exclusively by deleting pods (all consumers are in deletingPodUIDs) are excluded, since those
 //     pods are migrating off their nodes.
 //   - Releasable devices with no live consumers (unowned) are excluded.
+//   - For multi-allocatable (shared) devices that survive the above, the consumed capacity of any claim whose pods are
+//     all deleting is subtracted, so a deleting pod's share of a shared device is freed even when live pods keep the
+//     device itself in use.
 //
 // The remaining devices form the allocator's immutable seed set of already-allocated in-cluster devices, split into
 // exclusively-allocated devices and the consumed capacity of multi-allocatable (shared) devices.
@@ -106,18 +110,51 @@ func (p *Provisioner) gatherAllocatedDevices(ctx context.Context, deletingPodUID
 			continue
 		}
 		if meta.Shared {
-			// TODO(follow-up B1/B2): partial capacity subtraction for deleting pods. The exposed DeviceMetadata only
-			// carries the aggregated ConsumedCapacity across all claims, not the per-claim breakdown needed to free
-			// just the deleting pods' share of a shared device. Until the deviceallocation controller surfaces
-			// per-claim contributions, we pass the full aggregated capacity through unchanged. This is conservative:
-			// shared capacity held by deleting pods is not yet freed for reallocation (over-counts usage, never
-			// over-allocates).
-			state.ConsumedCapacity[id] = meta.ConsumedCapacity
+			// Free just the deleting pods' share of the device's consumed capacity. The device as a whole survives the
+			// all-consumers-deleting check above (live pods remain), but each contribution whose pods are all deleting
+			// is migrating off and its capacity should be available for reallocation.
+			effective := effectiveConsumedCapacity(meta, deletingPodUIDs)
+			if len(effective) == 0 {
+				// Every dimension was freed (or there was no live consumption left); treat the device as available.
+				continue
+			}
+			state.ConsumedCapacity[id] = effective
 			continue
 		}
 		state.ExclusiveDevices.Insert(id)
 	}
 	return state, nil
+}
+
+// effectiveConsumedCapacity computes a shared device's consumed capacity with the contributions of fully-deleting
+// claims removed. It starts from the aggregated capacity and subtracts each contribution whose reserving pods are all
+// deleting, dropping any dimension that reaches zero or below. The returned map is freshly allocated and never mutates
+// the controller's metadata.
+func effectiveConsumedCapacity(meta deviceallocation.DeviceMetadata, deletingPodUIDs sets.Set[types.UID]) map[resourcev1.QualifiedName]resource.Quantity {
+	effective := make(map[resourcev1.QualifiedName]resource.Quantity, len(meta.ConsumedCapacity))
+	for dim, qty := range meta.ConsumedCapacity {
+		effective[dim] = qty.DeepCopy()
+	}
+	for _, contribution := range meta.Contributions {
+		// A contribution reserved by no pods (e.g. a non-pod consumer) is never treated as deleting — only contributions
+		// whose entire pod set is being deleted are freed.
+		if len(contribution.PodUIDs) == 0 || !allConsumersDeleting(contribution.PodUIDs, deletingPodUIDs) {
+			continue
+		}
+		for dim, consumed := range contribution.ConsumedCapacity {
+			remaining, ok := effective[dim]
+			if !ok {
+				continue
+			}
+			remaining.Sub(consumed)
+			if remaining.Sign() <= 0 {
+				delete(effective, dim)
+				continue
+			}
+			effective[dim] = remaining
+		}
+	}
+	return effective
 }
 
 func allConsumersDeleting(podUIDs []types.UID, deletingPodUIDs sets.Set[types.UID]) bool {

--- a/pkg/controllers/provisioning/dra_internal_test.go
+++ b/pkg/controllers/provisioning/dra_internal_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var _ = Describe("DRA Provisioner Internals", func() {
+	Describe("nodeOwnerName", func() {
+		It("should return the Node owner reference name", func() {
+			slice := &resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Node", Name: "node-a"}},
+			}}
+			name, owned := nodeOwnerName(slice)
+			Expect(owned).To(BeTrue())
+			Expect(name).To(Equal("node-a"))
+		})
+		It("should report no owner when there are no owner references", func() {
+			slice := &resourcev1.ResourceSlice{}
+			_, owned := nodeOwnerName(slice)
+			Expect(owned).To(BeFalse())
+		})
+		It("should report no owner when no owner reference is a Node", func() {
+			slice := &resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Pod", Name: "pod-a"}},
+			}}
+			_, owned := nodeOwnerName(slice)
+			Expect(owned).To(BeFalse())
+		})
+		It("should find the Node owner reference among others", func() {
+			slice := &resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Pod", Name: "pod-a"}, {Kind: "Node", Name: "node-b"}},
+			}}
+			name, owned := nodeOwnerName(slice)
+			Expect(owned).To(BeTrue())
+			Expect(name).To(Equal("node-b"))
+		})
+	})
+
+	Describe("allConsumersDeleting", func() {
+		var deleting sets.Set[types.UID]
+
+		BeforeEach(func() {
+			deleting = sets.New[types.UID]("a", "b")
+		})
+
+		It("should be true when all consumers are deleting", func() {
+			Expect(allConsumersDeleting([]types.UID{"a", "b"}, deleting)).To(BeTrue())
+		})
+		It("should be true when consumers are a subset of deleting pods", func() {
+			Expect(allConsumersDeleting([]types.UID{"a"}, deleting)).To(BeTrue())
+		})
+		It("should be false when any consumer is not deleting", func() {
+			Expect(allConsumersDeleting([]types.UID{"a", "c"}, deleting)).To(BeFalse())
+		})
+		It("should be false when no consumer is deleting", func() {
+			Expect(allConsumersDeleting([]types.UID{"c"}, deleting)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/controllers/provisioning/dra_internal_test.go
+++ b/pkg/controllers/provisioning/dra_internal_test.go
@@ -20,9 +20,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 )
 
 var _ = Describe("DRA Provisioner Internals", func() {
@@ -75,6 +78,86 @@ var _ = Describe("DRA Provisioner Internals", func() {
 		})
 		It("should be false when no consumer is deleting", func() {
 			Expect(allConsumersDeleting([]types.UID{"c"}, deleting)).To(BeFalse())
+		})
+	})
+
+	Describe("effectiveConsumedCapacity", func() {
+		// contribution builds a single-claim contribution reserved by the given pods, consuming the given per-dimension
+		// capacity.
+		contribution := func(pods []types.UID, capacity map[resourcev1.QualifiedName]string) deviceallocation.ContributionMetadata {
+			consumed := map[resourcev1.QualifiedName]resource.Quantity{}
+			for dim, qty := range capacity {
+				consumed[dim] = resource.MustParse(qty)
+			}
+			return deviceallocation.ContributionMetadata{PodUIDs: pods, ConsumedCapacity: consumed}
+		}
+		// sharedMeta builds shared-device metadata whose aggregated ConsumedCapacity is the sum of its contributions.
+		sharedMeta := func(contributions ...deviceallocation.ContributionMetadata) deviceallocation.DeviceMetadata {
+			aggregate := map[resourcev1.QualifiedName]resource.Quantity{}
+			for _, c := range contributions {
+				for dim, qty := range c.ConsumedCapacity {
+					cur := aggregate[dim]
+					cur.Add(qty)
+					aggregate[dim] = cur
+				}
+			}
+			return deviceallocation.DeviceMetadata{Shared: true, ConsumedCapacity: aggregate, Contributions: contributions}
+		}
+		expectCapacity := func(actual map[resourcev1.QualifiedName]resource.Quantity, expected map[resourcev1.QualifiedName]string) {
+			GinkgoHelper()
+			Expect(actual).To(HaveLen(len(expected)))
+			for dim, qty := range expected {
+				got, ok := actual[dim]
+				Expect(ok).To(BeTrue(), "missing dimension %q", dim)
+				Expect(got.Equal(resource.MustParse(qty))).To(BeTrue(), "dimension %q: got %s, want %s", dim, got.String(), qty)
+			}
+		}
+
+		It("should retain full capacity when no consumer is deleting", func() {
+			meta := sharedMeta(
+				contribution([]types.UID{"live-a"}, map[resourcev1.QualifiedName]string{"memory": "256Mi", "connections": "1"}),
+				contribution([]types.UID{"live-b"}, map[resourcev1.QualifiedName]string{"memory": "128Mi", "connections": "3"}),
+			)
+			effective := effectiveConsumedCapacity(meta, sets.New[types.UID]())
+			expectCapacity(effective, map[resourcev1.QualifiedName]string{"memory": "384Mi", "connections": "4"})
+		})
+
+		It("should subtract only the deleting claim's share when mixed with live claims", func() {
+			meta := sharedMeta(
+				contribution([]types.UID{"live-a"}, map[resourcev1.QualifiedName]string{"memory": "256Mi", "connections": "1"}),
+				contribution([]types.UID{"deleting-b"}, map[resourcev1.QualifiedName]string{"memory": "128Mi", "connections": "3"}),
+			)
+			effective := effectiveConsumedCapacity(meta, sets.New[types.UID]("deleting-b"))
+			// Only the live claim's share remains.
+			expectCapacity(effective, map[resourcev1.QualifiedName]string{"memory": "256Mi", "connections": "1"})
+		})
+
+		It("should free a dimension entirely when the deleting claim consumed all of it", func() {
+			meta := sharedMeta(
+				contribution([]types.UID{"live-a"}, map[resourcev1.QualifiedName]string{"memory": "256Mi"}),
+				contribution([]types.UID{"deleting-b"}, map[resourcev1.QualifiedName]string{"memory": "128Mi", "connections": "3"}),
+			)
+			effective := effectiveConsumedCapacity(meta, sets.New[types.UID]("deleting-b"))
+			// connections was consumed solely by the deleting claim, so it drops out; memory keeps the live share.
+			expectCapacity(effective, map[resourcev1.QualifiedName]string{"memory": "256Mi"})
+		})
+
+		It("should return empty when every contribution is deleting", func() {
+			meta := sharedMeta(
+				contribution([]types.UID{"deleting-a"}, map[resourcev1.QualifiedName]string{"memory": "256Mi"}),
+				contribution([]types.UID{"deleting-b"}, map[resourcev1.QualifiedName]string{"memory": "128Mi"}),
+			)
+			effective := effectiveConsumedCapacity(meta, sets.New[types.UID]("deleting-a", "deleting-b"))
+			Expect(effective).To(BeEmpty())
+		})
+
+		It("should retain a contribution that mixes deleting and live pods", func() {
+			// A single claim reserved by both a deleting and a live pod is not fully deleting, so its capacity stays.
+			meta := sharedMeta(
+				contribution([]types.UID{"deleting-a", "live-b"}, map[resourcev1.QualifiedName]string{"memory": "256Mi"}),
+			)
+			effective := effectiveConsumedCapacity(meta, sets.New[types.UID]("deleting-a"))
+			expectCapacity(effective, map[resourcev1.QualifiedName]string{"memory": "256Mi"})
 		})
 	})
 })

--- a/pkg/controllers/provisioning/dra_test.go
+++ b/pkg/controllers/provisioning/dra_test.go
@@ -18,7 +18,6 @@ package provisioning_test
 
 import (
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,87 +42,53 @@ import (
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
 
+// The DRA test fixtures are shared across provisioning and disruption suites. Slice/claim builders live in pkg/test;
+// instance-type builders live in pkg/cloudprovider/fake (which imports pkg/test). These thin local aliases keep the
+// existing call sites in this file terse.
 const (
-	gpuDriver = "gpu.example.com"
-	nicDriver = "nic.example.com"
+	gpuDriver      = test.GPUDriver
+	nicDriver      = test.NICDriver
+	capacityMemory = test.CapacityMemory
+	counterSetName = "gpu-slices"
 )
 
-// gpuInstanceType builds a fake instance type publishing `count` GPU template devices under gpuDriver.
-//
+var (
+	clusterWideSlice          = test.ClusterWideSlice
+	zonedSlice                = test.ZonedSlice
+	sharedCapacitySlice       = test.SharedCapacitySlice
+	allocatedClusterWideClaim = test.AllocatedClusterWideClaim
+	allocatedSharedClaim      = test.AllocatedSharedClaim
+	podConsumer               = test.PodConsumer
+	gpuAndNICInstanceType     = fake.GPUAndNICInstanceType
+)
+
 //nolint:unparam
 func gpuInstanceType(name string, count int) *cloudprovider.InstanceType {
-	deviceNames := lo.Times(count, func(i int) string { return fmt.Sprintf("%s-gpu-%d", name, i) })
-	return fake.NewInstanceType(name,
-		fake.WithResourceSliceTemplates(fake.ResourceSliceTemplate(gpuDriver, name+"-pool", fake.Devices(deviceNames...)...)),
-	)
+	return fake.GPUInstanceType(name, count)
 }
 
-// gpuAndNICInstanceType builds a fake instance type publishing a GPU device under gpuDriver and a NIC device under
-// nicDriver, exercising multi-driver allocation on a single node.
-func gpuAndNICInstanceType(name string) *cloudprovider.InstanceType {
-	return fake.NewInstanceType(name,
-		fake.WithResourceSliceTemplates(
-			fake.ResourceSliceTemplate(gpuDriver, name+"-gpu-pool", fake.Devices(name+"-gpu-0")...),
-			fake.ResourceSliceTemplate(nicDriver, name+"-nic-pool", fake.Devices(name+"-nic-0")...),
-		),
-	)
+//nolint:unparam
+func nodeLocalSlice(node *corev1.Node, driver string, deviceNames ...string) *resourcev1.ResourceSlice {
+	return test.NodeLocalSlice(node, driver, deviceNames...)
 }
-
-// capacityMemory is the capacity dimension used by the consumable-capacity tests.
-const capacityMemory resourcev1.QualifiedName = gpuDriver + "/memory"
 
 // capacity builds a single-dimension (memory) capacity request map for the given quantity.
 func capacity(amount string) map[resourcev1.QualifiedName]resource.Quantity {
-	return map[resourcev1.QualifiedName]resource.Quantity{capacityMemory: resource.MustParse(amount)}
+	return test.CapacityRequest(amount)
 }
 
-// capacityGPUInstanceType builds a fake instance type publishing one multi-allocatable GPU template device with the
-// given total memory capacity (no RequestPolicy — capacity consumption is unconstrained).
-//
 //nolint:unparam
 func capacityGPUInstanceType(name, totalMemory string) *cloudprovider.InstanceType {
-	return fake.NewInstanceType(name, fake.WithResourceSliceTemplates(
-		fake.ResourceSliceTemplate(gpuDriver, name+"-pool",
-			fake.DeviceWith(name+"-gpu-0",
-				fake.WithMultipleAllocations(),
-				fake.WithCapacity(capacityMemory, resource.MustParse(totalMemory)),
-			),
-		),
-	))
+	return fake.CapacityGPUInstanceType(name, totalMemory, nil)
 }
 
-// capacityPolicyGPUInstanceType is capacityGPUInstanceType with a RequestPolicy constraining how the memory capacity
-// may be consumed.
 func capacityPolicyGPUInstanceType(name, totalMemory string, policy *resourcev1.CapacityRequestPolicy) *cloudprovider.InstanceType {
-	return fake.NewInstanceType(name, fake.WithResourceSliceTemplates(
-		fake.ResourceSliceTemplate(gpuDriver, name+"-pool",
-			fake.DeviceWith(name+"-gpu-0",
-				fake.WithMultipleAllocations(),
-				fake.WithCapacityPolicy(capacityMemory, resource.MustParse(totalMemory), policy),
-			),
-		),
-	))
+	return fake.CapacityGPUInstanceType(name, totalMemory, policy)
 }
 
-// counterSetName is the shared-counter set used by the partitionable-device tests.
-const counterSetName = "gpu-slices"
-
-// partitionableGPUInstanceType builds a fake instance type modeling a partitionable device: a pool with a shared
-// counter budget (counterSetName) and `profiles` device profiles, each consuming `perProfile` counters from the budget
-// on allocation. The counter set and the devices live in separate templates under the same pool (a slice may carry
-// either devices or shared counters, never both).
-//
 //nolint:unparam
 func partitionableGPUInstanceType(name string, budget map[string]resource.Quantity, profiles int, perProfile map[string]resource.Quantity) *cloudprovider.InstanceType {
-	deviceProfiles := lo.Times(profiles, func(i int) cloudprovider.Device {
-		return fake.DeviceWith(fmt.Sprintf("%s-profile-%d", name, i),
-			fake.WithConsumesCounters(fake.CounterConsumption(counterSetName, perProfile)),
-		)
-	})
-	return fake.NewInstanceType(name, fake.WithResourceSliceTemplates(
-		fake.ResourceSliceTemplateWithCounters(gpuDriver, name+"-pool", fake.CounterSet(counterSetName, budget)),
-		fake.ResourceSliceTemplate(gpuDriver, name+"-pool", deviceProfiles...),
-	))
+	return fake.PartitionableGPUInstanceType(name, counterSetName, budget, profiles, perProfile)
 }
 
 // quantities is a small convenience for building single- or multi-dimension counter maps inline.
@@ -151,149 +116,6 @@ func draPodForClaims(claims ...corev1.PodResourceClaim) *corev1.Pod {
 			return corev1.ResourceClaim{Name: c.Name}
 		}),
 	})
-}
-
-// nodeLocalSlice builds a published in-cluster ResourceSlice owned by and pinned to the given node via spec.nodeName —
-// the form kubelet/DRA drivers use for node-local devices. Such a slice is accessible only from the existing node with
-// that name. The pool name follows the framework's NodeLocalPoolName convention so device allocation status
-// reconciliation lines up.
-//
-//nolint:unparam
-func nodeLocalSlice(node *corev1.Node, driver string, deviceNames ...string) *resourcev1.ResourceSlice {
-	return test.ResourceSlice(resourcev1.ResourceSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", node.Name, sanitizeDriver(driver)),
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "v1",
-				Kind:       "Node",
-				Name:       node.Name,
-				UID:        node.UID,
-			}},
-		},
-		Spec: resourcev1.ResourceSliceSpec{
-			Driver:   driver,
-			NodeName: lo.ToPtr(node.Name),
-			Pool:     resourcev1.ResourcePool{Name: NodeLocalPoolName(driver, node.Name), Generation: 1, ResourceSliceCount: 1},
-			Devices:  lo.Map(deviceNames, func(name string, _ int) resourcev1.Device { return resourcev1.Device{Name: name} }),
-		},
-	})
-}
-
-// zonedSlice builds a published, cluster-managed ResourceSlice whose devices are constrained to a topology zone via a
-// NodeSelector. It is not owned by any node (cluster-managed), so it is always gathered, and its zone requirement is
-// propagated onto a NodeClaim that allocates from it.
-func zonedSlice(name, driver, zone string, deviceNames ...string) *resourcev1.ResourceSlice {
-	return test.ResourceSlice(resourcev1.ResourceSlice{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: resourcev1.ResourceSliceSpec{
-			Driver: driver,
-			Pool:   resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
-			NodeSelector: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
-				MatchExpressions: []corev1.NodeSelectorRequirement{{
-					Key:      corev1.LabelTopologyZone,
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{zone},
-				}},
-			}}},
-			Devices: lo.Map(deviceNames, func(name string, _ int) resourcev1.Device { return resourcev1.Device{Name: name} }),
-		},
-	})
-}
-
-func sanitizeDriver(driver string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(driver, ".", "-"), "/", "-")
-}
-
-// clusterWideSlice builds a published, cluster-wide (AllNodes) ResourceSlice. Its devices are accessible from any node
-// and the slice is always gathered (no node owner reference), isolating device-availability behavior from node state.
-func clusterWideSlice(name, driver string, deviceNames ...string) *resourcev1.ResourceSlice {
-	return test.ResourceSlice(resourcev1.ResourceSlice{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: resourcev1.ResourceSliceSpec{
-			Driver:   driver,
-			AllNodes: lo.ToPtr(true),
-			Pool:     resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
-			Devices:  lo.Map(deviceNames, func(n string, _ int) resourcev1.Device { return resourcev1.Device{Name: n} }),
-		},
-	})
-}
-
-// allocatedClusterWideClaim builds a ResourceClaim already allocated to a cluster-wide published device, reserved for
-// the given consumers. This seeds the deviceallocation controller's tracking so the allocator treats it as in-use.
-func allocatedClusterWideClaim(name, pool, driver, device string, consumers ...resourcev1.ResourceClaimConsumerReference) *resourcev1.ResourceClaim {
-	return test.ResourceClaim(resourcev1.ResourceClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
-		Spec: resourcev1.ResourceClaimSpec{
-			Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{test.ExactDeviceRequest("req", "gpu", 1)}},
-		},
-		Status: resourcev1.ResourceClaimStatus{
-			Allocation: &resourcev1.AllocationResult{
-				Devices: resourcev1.DeviceAllocationResult{
-					Results: []resourcev1.DeviceRequestAllocationResult{{
-						Request: "req",
-						Driver:  driver,
-						Pool:    pool,
-						Device:  device,
-					}},
-				},
-			},
-			ReservedFor: consumers,
-		},
-	})
-}
-
-// sharedCapacitySlice builds a published, cluster-wide (AllNodes) ResourceSlice whose single device is
-// multi-allocatable and publishes the given total memory capacity. Used to seed an in-cluster shared device for the
-// consumable-capacity reclaim test.
-func sharedCapacitySlice(name, driver, device, totalMemory string) *resourcev1.ResourceSlice {
-	return test.ResourceSlice(resourcev1.ResourceSlice{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: resourcev1.ResourceSliceSpec{
-			Driver:   driver,
-			AllNodes: lo.ToPtr(true),
-			Pool:     resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
-			Devices: []resourcev1.Device{{
-				Name:                     device,
-				AllowMultipleAllocations: lo.ToPtr(true),
-				Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
-					capacityMemory: {Value: resource.MustParse(totalMemory)},
-				},
-			}},
-		},
-	})
-}
-
-// allocatedSharedClaim builds a ResourceClaim already allocated to a shared (multi-allocatable) cluster-wide device,
-// consuming the given capacity and reserved for the given consumers. This seeds the deviceallocation controller so the
-// allocator sees the device's consumed capacity (and, via per-claim contributions, which pods hold which share).
-func allocatedSharedClaim(name, pool, driver, device string, consumed map[resourcev1.QualifiedName]resource.Quantity, consumers ...resourcev1.ResourceClaimConsumerReference) *resourcev1.ResourceClaim {
-	return test.ResourceClaim(resourcev1.ResourceClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
-		Spec: resourcev1.ResourceClaimSpec{
-			Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
-				test.ExactDeviceRequestWithCapacity("req", "gpu", 1, consumed),
-			}},
-		},
-		Status: resourcev1.ResourceClaimStatus{
-			Allocation: &resourcev1.AllocationResult{
-				Devices: resourcev1.DeviceAllocationResult{
-					Results: []resourcev1.DeviceRequestAllocationResult{{
-						Request:          "req",
-						Driver:           driver,
-						Pool:             pool,
-						Device:           device,
-						ConsumedCapacity: consumed,
-					}},
-				},
-			},
-			ReservedFor: consumers,
-		},
-	})
-}
-
-// podConsumer builds a ResourceClaimConsumerReference for a pod.
-func podConsumer(pod *corev1.Pod) resourcev1.ResourceClaimConsumerReference {
-	return resourcev1.ResourceClaimConsumerReference{Resource: "pods", Name: pod.Name, UID: pod.UID}
 }
 
 var _ = Describe("Dynamic Resource Allocation", func() {
@@ -776,7 +598,7 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 			Expect(scheduled.Name).To(Equal(node.Name))
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
 			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
-			Expect(devices).To(ConsistOf(NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
+			Expect(devices).To(ConsistOf(test.NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
 		})
 		It("should prefer an existing node's published device over launching a new node (C2)", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
@@ -967,7 +789,7 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 			scheduled := ExpectScheduled(ctx, env.Client, pod)
 			Expect(scheduled.Name).ToNot(Equal(node.Name))
 			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
-			Expect(devices).ToNot(ConsistOf(NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
+			Expect(devices).ToNot(ConsistOf(test.NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
 		})
 		It("should exclude slices owned by a node not in cluster state (S2)", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
@@ -989,7 +811,7 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 			// The orphan slice is excluded, so the pod is satisfied via a new NodeClaim's template device.
 			ExpectScheduled(ctx, env.Client, pod)
 			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
-			Expect(devices).ToNot(ConsistOf(NodeLocalPoolName(gpuDriver, orphanNode.Name) + "/orphan-gpu-0"))
+			Expect(devices).ToNot(ConsistOf(test.NodeLocalPoolName(gpuDriver, orphanNode.Name) + "/orphan-gpu-0"))
 		})
 	})
 
@@ -1012,7 +834,7 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 			// The pod schedules and its device is not the excluded published device.
 			ExpectScheduled(ctx, env.Client, pod)
 			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
-			Expect(devices).ToNot(ConsistOf(NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
+			Expect(devices).ToNot(ConsistOf(test.NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
 		})
 		It("should not double-count a node's devices across the uninitialized→initialized transition (I2)", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
@@ -1031,7 +853,7 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 			provisionDRA(podA)
 			ExpectScheduled(ctx, env.Client, podA)
 			devicesA := ExpectResourceClaimAllocated(ctx, env.Client, "default", "claim-a", gpuDriver)
-			Expect(devicesA).ToNot(ConsistOf(NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
+			Expect(devicesA).ToNot(ConsistOf(test.NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
 
 			// Initialize the node so its published slice becomes authoritative for subsequent runs.
 			ExpectMakeNodesInitialized(ctx, env.Client, env.Clock, node)

--- a/pkg/controllers/provisioning/dra_test.go
+++ b/pkg/controllers/provisioning/dra_test.go
@@ -79,6 +79,8 @@ func capacity(amount string) map[resourcev1.QualifiedName]resource.Quantity {
 
 // capacityGPUInstanceType builds a fake instance type publishing one multi-allocatable GPU template device with the
 // given total memory capacity (no RequestPolicy — capacity consumption is unconstrained).
+//
+//nolint:unparam
 func capacityGPUInstanceType(name, totalMemory string) *cloudprovider.InstanceType {
 	return fake.NewInstanceType(name, fake.WithResourceSliceTemplates(
 		fake.ResourceSliceTemplate(gpuDriver, name+"-pool",
@@ -101,6 +103,36 @@ func capacityPolicyGPUInstanceType(name, totalMemory string, policy *resourcev1.
 			),
 		),
 	))
+}
+
+// counterSetName is the shared-counter set used by the partitionable-device tests.
+const counterSetName = "gpu-slices"
+
+// partitionableGPUInstanceType builds a fake instance type modeling a partitionable device: a pool with a shared
+// counter budget (counterSetName) and `profiles` device profiles, each consuming `perProfile` counters from the budget
+// on allocation. The counter set and the devices live in separate templates under the same pool (a slice may carry
+// either devices or shared counters, never both).
+//
+//nolint:unparam
+func partitionableGPUInstanceType(name string, budget map[string]resource.Quantity, profiles int, perProfile map[string]resource.Quantity) *cloudprovider.InstanceType {
+	deviceProfiles := lo.Times(profiles, func(i int) cloudprovider.Device {
+		return fake.DeviceWith(fmt.Sprintf("%s-profile-%d", name, i),
+			fake.WithConsumesCounters(fake.CounterConsumption(counterSetName, perProfile)),
+		)
+	})
+	return fake.NewInstanceType(name, fake.WithResourceSliceTemplates(
+		fake.ResourceSliceTemplateWithCounters(gpuDriver, name+"-pool", fake.CounterSet(counterSetName, budget)),
+		fake.ResourceSliceTemplate(gpuDriver, name+"-pool", deviceProfiles...),
+	))
+}
+
+// quantities is a small convenience for building single- or multi-dimension counter maps inline.
+func quantities(pairs ...string) map[string]resource.Quantity {
+	m := map[string]resource.Quantity{}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		m[pairs[i]] = resource.MustParse(pairs[i+1])
+	}
+	return m
 }
 
 // draPod builds an unschedulable pod referencing the named ResourceClaim from its container.
@@ -1215,6 +1247,131 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 			}
 			Expect(nodeNames.Len()).To(Equal(1), "default 4Gi consumption lets three pods share one 16Gi device")
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		})
+	})
+
+	Context("Partitionable devices (K)", func() {
+		BeforeEach(func() {
+			if env.Version.Minor() < 36 {
+				Skip("Partitionable devices require K8s versions >= 1.36.x (DRAConsumableCapacity feature gate)")
+			}
+		})
+
+		It("should pack counter-constrained profiles onto one NodeClaim within budget (K1)", func() {
+			// Budget memory:80Gi; two profiles each consume 40Gi → both fit on one node's pool.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				partitionableGPUInstanceType("gpu-it", quantities("memory", "80Gi"), 2, quantities("memory", "40Gi")),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("claim-a", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("claim-b", test.ExactDeviceRequest("req", "gpu", 1)),
+			)
+			podA := draPod("gpu", "claim-a")
+			podB := draPod("gpu", "claim-b")
+			provisionDRA(podA, podB)
+
+			nodeA := ExpectScheduled(ctx, env.Client, podA)
+			nodeB := ExpectScheduled(ctx, env.Client, podB)
+			Expect(nodeA.Name).To(Equal(nodeB.Name), "both 40Gi profiles fit within the 80Gi counter budget on one node")
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		})
+
+		It("should create a second NodeClaim when the counter budget is exhausted (K2)", func() {
+			// Budget 80Gi; three 40Gi profiles (120Gi) cannot all draw from one pool → a second node is required.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				partitionableGPUInstanceType("gpu-it", quantities("memory", "80Gi"), 3, quantities("memory", "40Gi")),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			pods := lo.Times(3, func(i int) *corev1.Pod {
+				name := fmt.Sprintf("claim-%d", i)
+				ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests(name, test.ExactDeviceRequest("req", "gpu", 1)))
+				return draPod("gpu", name)
+			})
+			provisionDRA(pods...)
+
+			nodeNames := sets.New[string]()
+			for _, pod := range pods {
+				nodeNames.Insert(ExpectScheduled(ctx, env.Client, pod).Name)
+			}
+			Expect(nodeNames.Len()).To(Equal(2), "120Gi of profiles cannot fit in a single 80Gi counter budget")
+		})
+
+		It("should track multiple counter dimensions independently (K3)", func() {
+			// Budget memory:80Gi, compute:100. Two profiles consume memory:40Gi + compute:50 each → both fit.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				partitionableGPUInstanceType("gpu-it", quantities("memory", "80Gi", "compute", "100"), 2, quantities("memory", "40Gi", "compute", "50")),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("claim-a", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("claim-b", test.ExactDeviceRequest("req", "gpu", 1)),
+			)
+			podA := draPod("gpu", "claim-a")
+			podB := draPod("gpu", "claim-b")
+			provisionDRA(podA, podB)
+
+			nodeA := ExpectScheduled(ctx, env.Client, podA)
+			nodeB := ExpectScheduled(ctx, env.Client, podB)
+			Expect(nodeA.Name).To(Equal(nodeB.Name), "both profiles fit within memory and compute budgets on one node")
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		})
+
+		It("should fail to schedule when a single profile exceeds the counter budget (K5)", func() {
+			// Budget memory:40Gi; the single profile consumes 80Gi — over budget, so no device is allocatable.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				partitionableGPUInstanceType("gpu-it", quantities("memory", "40Gi"), 1, quantities("memory", "80Gi")),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+
+		It("should reject a pool whose device references a non-existent counter set (K6)", func() {
+			// The device consumes from a counter set name that the pool's SharedCounters doesn't define. The allocator
+			// marks the pool invalid (getAndValidateCounterSets / validateDeviceCounterConsumption), so no device is
+			// allocatable and the pod can't schedule.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				fake.NewInstanceType("gpu-it", fake.WithResourceSliceTemplates(
+					fake.ResourceSliceTemplateWithCounters(gpuDriver, "gpu-it-pool", fake.CounterSet(counterSetName, quantities("memory", "80Gi"))),
+					fake.ResourceSliceTemplate(gpuDriver, "gpu-it-pool",
+						fake.DeviceWith("gpu-it-profile-0",
+							fake.WithConsumesCounters(fake.CounterConsumption("nonexistent-counter-set", quantities("memory", "40Gi"))),
+						),
+					),
+				)),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+
+		It("should never co-locate profiles whose combined consumption exceeds a dimension budget (K7)", func() {
+			// Budget compute:100; two profiles each consume compute:60 (120 > 100). They must land on separate nodes.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				partitionableGPUInstanceType("gpu-it", quantities("compute", "100"), 2, quantities("compute", "60")),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("claim-a", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("claim-b", test.ExactDeviceRequest("req", "gpu", 1)),
+			)
+			podA := draPod("gpu", "claim-a")
+			podB := draPod("gpu", "claim-b")
+			provisionDRA(podA, podB)
+
+			nodeA := ExpectScheduled(ctx, env.Client, podA)
+			nodeB := ExpectScheduled(ctx, env.Client, podB)
+			Expect(nodeA.Name).ToNot(Equal(nodeB.Name), "60+60 compute exceeds the 100 budget, so the profiles can't share a pool")
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))
 		})
 	})
 })

--- a/pkg/controllers/provisioning/dra_test.go
+++ b/pkg/controllers/provisioning/dra_test.go
@@ -333,7 +333,7 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 		})
 	})
 
-	Context("dra-drivers annotation (G)", func() {
+	Context("requested-dra-drivers annotation (G)", func() {
 		It("should list every driver whose devices were allocated (G1)", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuAndNICInstanceType("multi-it")}
 			ExpectApplied(ctx, env.Client, nodePool,

--- a/pkg/controllers/provisioning/dra_test.go
+++ b/pkg/controllers/provisioning/dra_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -66,6 +67,40 @@ func gpuAndNICInstanceType(name string) *cloudprovider.InstanceType {
 			fake.ResourceSliceTemplate(nicDriver, name+"-nic-pool", fake.Devices(name+"-nic-0")...),
 		),
 	)
+}
+
+// capacityMemory is the capacity dimension used by the consumable-capacity tests.
+const capacityMemory resourcev1.QualifiedName = gpuDriver + "/memory"
+
+// capacity builds a single-dimension (memory) capacity request map for the given quantity.
+func capacity(amount string) map[resourcev1.QualifiedName]resource.Quantity {
+	return map[resourcev1.QualifiedName]resource.Quantity{capacityMemory: resource.MustParse(amount)}
+}
+
+// capacityGPUInstanceType builds a fake instance type publishing one multi-allocatable GPU template device with the
+// given total memory capacity (no RequestPolicy — capacity consumption is unconstrained).
+func capacityGPUInstanceType(name, totalMemory string) *cloudprovider.InstanceType {
+	return fake.NewInstanceType(name, fake.WithResourceSliceTemplates(
+		fake.ResourceSliceTemplate(gpuDriver, name+"-pool",
+			fake.DeviceWith(name+"-gpu-0",
+				fake.WithMultipleAllocations(),
+				fake.WithCapacity(capacityMemory, resource.MustParse(totalMemory)),
+			),
+		),
+	))
+}
+
+// capacityPolicyGPUInstanceType is capacityGPUInstanceType with a RequestPolicy constraining how the memory capacity
+// may be consumed.
+func capacityPolicyGPUInstanceType(name, totalMemory string, policy *resourcev1.CapacityRequestPolicy) *cloudprovider.InstanceType {
+	return fake.NewInstanceType(name, fake.WithResourceSliceTemplates(
+		fake.ResourceSliceTemplate(gpuDriver, name+"-pool",
+			fake.DeviceWith(name+"-gpu-0",
+				fake.WithMultipleAllocations(),
+				fake.WithCapacityPolicy(capacityMemory, resource.MustParse(totalMemory), policy),
+			),
+		),
+	))
 }
 
 // draPod builds an unschedulable pod referencing the named ResourceClaim from its container.
@@ -167,6 +202,55 @@ func allocatedClusterWideClaim(name, pool, driver, device string, consumers ...r
 						Driver:  driver,
 						Pool:    pool,
 						Device:  device,
+					}},
+				},
+			},
+			ReservedFor: consumers,
+		},
+	})
+}
+
+// sharedCapacitySlice builds a published, cluster-wide (AllNodes) ResourceSlice whose single device is
+// multi-allocatable and publishes the given total memory capacity. Used to seed an in-cluster shared device for the
+// consumable-capacity reclaim test.
+func sharedCapacitySlice(name, driver, device, totalMemory string) *resourcev1.ResourceSlice {
+	return test.ResourceSlice(resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver:   driver,
+			AllNodes: lo.ToPtr(true),
+			Pool:     resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
+			Devices: []resourcev1.Device{{
+				Name:                     device,
+				AllowMultipleAllocations: lo.ToPtr(true),
+				Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+					capacityMemory: {Value: resource.MustParse(totalMemory)},
+				},
+			}},
+		},
+	})
+}
+
+// allocatedSharedClaim builds a ResourceClaim already allocated to a shared (multi-allocatable) cluster-wide device,
+// consuming the given capacity and reserved for the given consumers. This seeds the deviceallocation controller so the
+// allocator sees the device's consumed capacity (and, via per-claim contributions, which pods hold which share).
+func allocatedSharedClaim(name, pool, driver, device string, consumed map[resourcev1.QualifiedName]resource.Quantity, consumers ...resourcev1.ResourceClaimConsumerReference) *resourcev1.ResourceClaim {
+	return test.ResourceClaim(resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+				test.ExactDeviceRequestWithCapacity("req", "gpu", 1, consumed),
+			}},
+		},
+		Status: resourcev1.ResourceClaimStatus{
+			Allocation: &resourcev1.AllocationResult{
+				Devices: resourcev1.DeviceAllocationResult{
+					Results: []resourcev1.DeviceRequestAllocationResult{{
+						Request:          "req",
+						Driver:           driver,
+						Pool:             pool,
+						Device:           device,
+						ConsumedCapacity: consumed,
 					}},
 				},
 			},
@@ -930,6 +1014,207 @@ var _ = Describe("Dynamic Resource Allocation", func() {
 			ExpectScheduled(ctx, env.Client, podB)
 			devicesB := ExpectResourceClaimAllocated(ctx, env.Client, "default", "claim-b", gpuDriver)
 			Expect(devicesB).To(HaveLen(1), "the initialized node's published device is allocated exactly once")
+		})
+	})
+
+	Context("Consumable capacity (P)", func() {
+		BeforeEach(func() {
+			if env.Version.Minor() < 36 {
+				Skip("Consumable capacity requires K8s versions >= 1.36.x (DRAConsumableCapacity feature gate)")
+			}
+		})
+
+		It("should provision a node and allocate a capacity slice of a multi-allocatable device (P1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{capacityGPUInstanceType("gpu-it", "16Gi")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"},
+				Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+					test.ExactDeviceRequestWithCapacity("req", "gpu", 1, capacity("4Gi")),
+				}}},
+			}))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+			ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
+		})
+
+		It("should pack multiple pods onto one multi-allocatable device via capacity (P2)", func() {
+			// A single multi-allocatable device with 16Gi; three pods each consume 4Gi (12Gi <= 16Gi), so all three
+			// share the one device on a single NodeClaim — the core consumable-capacity packing win.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{capacityGPUInstanceType("gpu-it", "16Gi")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			pods := lo.Times(3, func(i int) *corev1.Pod {
+				name := fmt.Sprintf("cap-claim-%d", i)
+				ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+						test.ExactDeviceRequestWithCapacity("req", "gpu", 1, capacity("4Gi")),
+					}}},
+				}))
+				return draPod("gpu", name)
+			})
+			provisionDRA(pods...)
+
+			nodeNames := sets.New[string]()
+			for _, pod := range pods {
+				nodeNames.Insert(ExpectScheduled(ctx, env.Client, pod).Name)
+			}
+			Expect(nodeNames.Len()).To(Equal(1), "all three capacity slices fit on one shared device on one node")
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		})
+
+		It("should create a second NodeClaim when device capacity is exhausted (P3)", func() {
+			// 16Gi device per node. Three 4Gi pods fit (12Gi); a fourth 8Gi pod (20Gi total) cannot share, forcing a
+			// second node.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{capacityGPUInstanceType("gpu-it", "16Gi")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			var pods []*corev1.Pod
+			for i, amount := range []string{"4Gi", "4Gi", "4Gi", "8Gi"} {
+				name := fmt.Sprintf("cap-claim-%d", i)
+				ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+						test.ExactDeviceRequestWithCapacity("req", "gpu", 1, capacity(amount)),
+					}}},
+				}))
+				pods = append(pods, draPod("gpu", name))
+			}
+			provisionDRA(pods...)
+
+			nodeNames := sets.New[string]()
+			for _, pod := range pods {
+				nodeNames.Insert(ExpectScheduled(ctx, env.Client, pod).Name)
+			}
+			Expect(nodeNames.Len()).To(Equal(2), "20Gi of requests cannot fit on a single 16Gi device")
+		})
+
+		It("should reclaim a deleting pod's capacity share of a shared device (P4)", func() {
+			// A cluster-wide multi-allocatable device with 16Gi, partially consumed: a live pod holds 4Gi and a pod on a
+			// deleting node holds 10Gi. Only 2Gi is nominally free, but the deleting pod's 10Gi must be reclaimed, so a
+			// new 10Gi claim fits on the existing device (exercises B2 partial subtraction end to end).
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("plain-it")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, sharedCapacitySlice("shared-gpu-pool", gpuDriver, "shared-gpu-0", "16Gi"))
+
+			// A live pod holds 4Gi of the shared device — this share must NOT be reclaimed.
+			livePod := test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Name: "live-pod"}})
+			ExpectApplied(ctx, env.Client, livePod)
+			ExpectApplied(ctx, env.Client, allocatedSharedClaim("live-claim", "shared-gpu-pool", gpuDriver, "shared-gpu-0", capacity("4Gi"), podConsumer(livePod)))
+
+			// A pod on a deleting node holds 10Gi — its share must be reclaimed when the node is deleted.
+			deletingNode := existingNode("plain-it", true, corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("4Gi"), corev1.ResourcePods: resource.MustParse("10"),
+			})
+			deletingPod := test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Name: "deleting-pod"}})
+			ExpectApplied(ctx, env.Client, deletingPod)
+			ExpectManualBinding(ctx, env.Client, deletingPod, deletingNode)
+			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(deletingNode))
+			ExpectApplied(ctx, env.Client, allocatedSharedClaim("deleting-claim", "shared-gpu-pool", gpuDriver, "shared-gpu-0", capacity("10Gi"), podConsumer(deletingPod)))
+
+			// Mark the node for deletion so its pod's 10Gi share is freed.
+			Expect(env.Client.Delete(ctx, deletingNode)).To(Succeed())
+			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(deletingNode))
+
+			// A new 10Gi claim only fits if the deleting pod's share was reclaimed (16 - 4 live = 12Gi available).
+			ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-claim", Namespace: "default"},
+				Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+					test.ExactDeviceRequestWithCapacity("req", "gpu", 1, capacity("10Gi")),
+				}}},
+			}))
+			pod := draPod("gpu", "new-claim")
+			provisionDRA(pod)
+
+			// plain-it provides no template GPUs, so the cluster-wide shared device is the only thing that can satisfy the
+			// 10Gi claim — and only if the deleting pod's 10Gi share was reclaimed (16 - 4 live = 12Gi available). The
+			// allocation to shared-gpu-0 is the proof of partial reclaim; the pod runs on a fresh node that the AllNodes
+			// device attaches to.
+			ExpectScheduled(ctx, env.Client, pod)
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "new-claim", gpuDriver)
+			Expect(devices).To(ConsistOf("shared-gpu-pool/shared-gpu-0"))
+		})
+
+		It("should fail to schedule when a single request exceeds total device capacity (P6)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{capacityGPUInstanceType("gpu-it", "16Gi")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"},
+				Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+					test.ExactDeviceRequestWithCapacity("req", "gpu", 1, capacity("32Gi")),
+				}}},
+			}))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+
+		It("should fail to schedule when a requested capacity dimension is not offered (P8)", func() {
+			// The device offers only "memory" capacity; a request for "bandwidth" can't be satisfied by any device.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{capacityGPUInstanceType("gpu-it", "16Gi")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"},
+				Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+					test.ExactDeviceRequestWithCapacity("req", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
+						capacityMemory: resource.MustParse("4Gi"),
+						"bandwidth":    resource.MustParse("10"),
+					}),
+				}}},
+			}))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+
+		It("should reject a request that violates a ValidValues RequestPolicy (P9)", func() {
+			// Device capacity restricted to {4Gi,8Gi,16Gi}; a 32Gi request exceeds all valid values and is rejected.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{capacityPolicyGPUInstanceType("gpu-it", "16Gi",
+				&resourcev1.CapacityRequestPolicy{
+					Default:     lo.ToPtr(resource.MustParse("4Gi")),
+					ValidValues: []resource.Quantity{resource.MustParse("4Gi"), resource.MustParse("8Gi"), resource.MustParse("16Gi")},
+				})}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"},
+				Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+					test.ExactDeviceRequestWithCapacity("req", "gpu", 1, capacity("32Gi")),
+				}}},
+			}))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+
+		It("should apply RequestPolicy.Default for an unspecified dimension, enabling packing (P10)", func() {
+			// Device has 16Gi with a Default consumption of 4Gi. Three pods that request the device WITHOUT naming the
+			// capacity dimension each consume the 4Gi default (not the whole device), so all three pack onto one device.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{capacityPolicyGPUInstanceType("gpu-it", "16Gi",
+				&resourcev1.CapacityRequestPolicy{Default: lo.ToPtr(resource.MustParse("4Gi"))})}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			pods := lo.Times(3, func(i int) *corev1.Pod {
+				name := fmt.Sprintf("default-claim-%d", i)
+				// No capacity request — the device's RequestPolicy.Default (4Gi) governs consumption.
+				ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests(name, test.ExactDeviceRequest("req", "gpu", 1)))
+				return draPod("gpu", name)
+			})
+			provisionDRA(pods...)
+
+			nodeNames := sets.New[string]()
+			for _, pod := range pods {
+				nodeNames.Insert(ExpectScheduled(ctx, env.Client, pod).Name)
+			}
+			Expect(nodeNames.Len()).To(Equal(1), "default 4Gi consumption lets three pods share one 16Gi device")
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
 		})
 	})
 })

--- a/pkg/controllers/provisioning/dra_test.go
+++ b/pkg/controllers/provisioning/dra_test.go
@@ -1,0 +1,935 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
+	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
+	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+)
+
+const (
+	gpuDriver = "gpu.example.com"
+	nicDriver = "nic.example.com"
+)
+
+// gpuInstanceType builds a fake instance type publishing `count` GPU template devices under gpuDriver.
+//
+//nolint:unparam
+func gpuInstanceType(name string, count int) *cloudprovider.InstanceType {
+	deviceNames := lo.Times(count, func(i int) string { return fmt.Sprintf("%s-gpu-%d", name, i) })
+	return fake.NewInstanceType(name,
+		fake.WithResourceSliceTemplates(fake.ResourceSliceTemplate(gpuDriver, name+"-pool", fake.Devices(deviceNames...)...)),
+	)
+}
+
+// gpuAndNICInstanceType builds a fake instance type publishing a GPU device under gpuDriver and a NIC device under
+// nicDriver, exercising multi-driver allocation on a single node.
+func gpuAndNICInstanceType(name string) *cloudprovider.InstanceType {
+	return fake.NewInstanceType(name,
+		fake.WithResourceSliceTemplates(
+			fake.ResourceSliceTemplate(gpuDriver, name+"-gpu-pool", fake.Devices(name+"-gpu-0")...),
+			fake.ResourceSliceTemplate(nicDriver, name+"-nic-pool", fake.Devices(name+"-nic-0")...),
+		),
+	)
+}
+
+// draPod builds an unschedulable pod referencing the named ResourceClaim from its container.
+//
+//nolint:unparam
+func draPod(claimRef, claimName string) *corev1.Pod {
+	return draPodForClaims(test.PodResourceClaimReference(claimRef, claimName))
+}
+
+// draPodForClaims builds an unschedulable pod that references each of the provided pod resource claims from its
+// container.
+func draPodForClaims(claims ...corev1.PodResourceClaim) *corev1.Pod {
+	return test.UnschedulablePod(test.PodOptions{
+		ResourceClaims: claims,
+		ContainerResourceClaims: lo.Map(claims, func(c corev1.PodResourceClaim, _ int) corev1.ResourceClaim {
+			return corev1.ResourceClaim{Name: c.Name}
+		}),
+	})
+}
+
+// nodeLocalSlice builds a published in-cluster ResourceSlice owned by and pinned to the given node via spec.nodeName —
+// the form kubelet/DRA drivers use for node-local devices. Such a slice is accessible only from the existing node with
+// that name. The pool name follows the framework's NodeLocalPoolName convention so device allocation status
+// reconciliation lines up.
+//
+//nolint:unparam
+func nodeLocalSlice(node *corev1.Node, driver string, deviceNames ...string) *resourcev1.ResourceSlice {
+	return test.ResourceSlice(resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%s", node.Name, sanitizeDriver(driver)),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       node.Name,
+				UID:        node.UID,
+			}},
+		},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver:   driver,
+			NodeName: lo.ToPtr(node.Name),
+			Pool:     resourcev1.ResourcePool{Name: NodeLocalPoolName(driver, node.Name), Generation: 1, ResourceSliceCount: 1},
+			Devices:  lo.Map(deviceNames, func(name string, _ int) resourcev1.Device { return resourcev1.Device{Name: name} }),
+		},
+	})
+}
+
+// zonedSlice builds a published, cluster-managed ResourceSlice whose devices are constrained to a topology zone via a
+// NodeSelector. It is not owned by any node (cluster-managed), so it is always gathered, and its zone requirement is
+// propagated onto a NodeClaim that allocates from it.
+func zonedSlice(name, driver, zone string, deviceNames ...string) *resourcev1.ResourceSlice {
+	return test.ResourceSlice(resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver: driver,
+			Pool:   resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
+			NodeSelector: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key:      corev1.LabelTopologyZone,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{zone},
+				}},
+			}}},
+			Devices: lo.Map(deviceNames, func(name string, _ int) resourcev1.Device { return resourcev1.Device{Name: name} }),
+		},
+	})
+}
+
+func sanitizeDriver(driver string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(driver, ".", "-"), "/", "-")
+}
+
+// clusterWideSlice builds a published, cluster-wide (AllNodes) ResourceSlice. Its devices are accessible from any node
+// and the slice is always gathered (no node owner reference), isolating device-availability behavior from node state.
+func clusterWideSlice(name, driver string, deviceNames ...string) *resourcev1.ResourceSlice {
+	return test.ResourceSlice(resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver:   driver,
+			AllNodes: lo.ToPtr(true),
+			Pool:     resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
+			Devices:  lo.Map(deviceNames, func(n string, _ int) resourcev1.Device { return resourcev1.Device{Name: n} }),
+		},
+	})
+}
+
+// allocatedClusterWideClaim builds a ResourceClaim already allocated to a cluster-wide published device, reserved for
+// the given consumers. This seeds the deviceallocation controller's tracking so the allocator treats it as in-use.
+func allocatedClusterWideClaim(name, pool, driver, device string, consumers ...resourcev1.ResourceClaimConsumerReference) *resourcev1.ResourceClaim {
+	return test.ResourceClaim(resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{test.ExactDeviceRequest("req", "gpu", 1)}},
+		},
+		Status: resourcev1.ResourceClaimStatus{
+			Allocation: &resourcev1.AllocationResult{
+				Devices: resourcev1.DeviceAllocationResult{
+					Results: []resourcev1.DeviceRequestAllocationResult{{
+						Request: "req",
+						Driver:  driver,
+						Pool:    pool,
+						Device:  device,
+					}},
+				},
+			},
+			ReservedFor: consumers,
+		},
+	})
+}
+
+// podConsumer builds a ResourceClaimConsumerReference for a pod.
+func podConsumer(pod *corev1.Pod) resourcev1.ResourceClaimConsumerReference {
+	return resourcev1.ResourceClaimConsumerReference{Resource: "pods", Name: pod.Name, UID: pod.UID}
+}
+
+var _ = Describe("Dynamic Resource Allocation", func() {
+	var nodePool *v1.NodePool
+	var draProvisioner *provisioning.Provisioner
+	var draController *deviceallocation.Controller
+
+	BeforeEach(func() {
+		if env.Version.Minor() < 34 {
+			Skip("DRA is only available in K8s versions >= 1.34.x")
+		}
+		// DRA support is gated off by default; enable it for these tests.
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{IgnoreDRARequests: lo.ToPtr(false)}))
+		nodePool = test.NodePool()
+		// Use a provisioner backed by a fresh deviceallocation controller so each test starts with clean
+		// allocated-device tracking state. The controller must be reconciled (hydrated) before a provisioning round
+		// that relies on the in-cluster allocated-device set — see provisionDRA.
+		draController = deviceallocation.NewController(env.Client)
+		draProvisioner = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock, draController)
+	})
+
+	// provisionDRA reconciles the deviceallocation controller (so the allocator sees the current in-cluster allocated
+	// devices) and then runs a provisioning round.
+	provisionDRA := func(pods ...*corev1.Pod) ProvisioningResult {
+		GinkgoHelper()
+		ExpectDeviceAllocationReconciled(ctx, env.Client, draController)
+		return ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, draProvisioner, pods...)
+	}
+
+	// existingNode creates a managed node belonging to nodePool with the given instance type and capacity, applies it,
+	// optionally marks it initialized, and registers it in cluster state so the scheduler evaluates it as an existing
+	// node. The returned node carries a UID (for ResourceSlice owner references) and a hostname label (so node-local
+	// published slices can target it via a NodeSelector).
+	existingNode := func(instanceType string, initialized bool, capacity corev1.ResourceList) *corev1.Node {
+		GinkgoHelper()
+		node := test.Node(test.NodeOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1.NodePoolLabelKey:            nodePool.Name,
+					corev1.LabelInstanceTypeStable: instanceType,
+					v1.NodeRegisteredLabelKey:      "true",
+				},
+				Finalizers: []string{v1.TerminationFinalizer},
+			},
+			// A provider ID is required for the node to be tracked in cluster state and evaluated as an existing node.
+			ProviderID:  test.RandomProviderID(),
+			Capacity:    capacity,
+			Allocatable: capacity,
+		})
+		node.Labels[corev1.LabelHostname] = node.Name
+		ExpectApplied(ctx, env.Client, node)
+		if initialized {
+			ExpectMakeNodesInitialized(ctx, env.Client, env.Clock, node)
+		}
+		node = ExpectExists(ctx, env.Client, node)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+		return node
+	}
+
+	Context("Single unallocated claim (A)", func() {
+		It("should provision a new NodeClaim, allocate the claim, and annotate the drivers (A1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 2)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			claim := test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1))
+			ExpectApplied(ctx, env.Client, claim)
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels[corev1.LabelInstanceTypeStable]).To(Equal("gpu-it"))
+
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(nodeClaims).To(HaveLen(1))
+			ExpectNodeClaimDRADrivers(nodeClaims[0], gpuDriver)
+			ExpectResourceClaimAllocated(ctx, env.Client, claim.Namespace, claim.Name, gpuDriver)
+		})
+		It("should restrict instance types to those providing the requested device (A2)", func() {
+			// Only gpu-it provides the GPU device; no-gpu-it does not.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				gpuInstanceType("gpu-it", 1),
+				fake.NewInstanceType("no-gpu-it"),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(nodeClaims).To(HaveLen(1))
+			Expect(nodeClaims[0].Status.NodeName).ToNot(BeEmpty())
+			Expect(nodeClaims[0].Labels[corev1.LabelInstanceTypeStable]).To(Equal("gpu-it"))
+		})
+		It("should not annotate or allocate for a non-DRA pod (A3)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool)
+
+			pod := test.UnschedulablePod()
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(nodeClaims).To(HaveLen(1))
+			Expect(nodeClaims[0].Annotations).ToNot(HaveKey(v1.DRADriversAnnotationKey))
+		})
+		It("should resolve and allocate a claim generated from a ResourceClaimTemplate (A4)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			// The pod references a ResourceClaimTemplate; the framework generates the per-pod claim (the integration
+			// analog of the in-cluster claim-template controller) before scheduling.
+			ExpectApplied(ctx, env.Client, test.ResourceClaimTemplate(resourcev1.ResourceClaimTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "default"},
+				Spec: resourcev1.ResourceClaimTemplateSpec{Spec: resourcev1.ResourceClaimSpec{
+					Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{test.ExactDeviceRequest("req", "gpu", 1)}},
+				}},
+			}))
+
+			pod := draPodForClaims(test.PodResourceClaimTemplateReference("gpu", "gpu-template"))
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(nodeClaims).To(HaveLen(1))
+			ExpectNodeClaimDRADrivers(nodeClaims[0], gpuDriver)
+			// The generated claim is named "<pod>-<claimRef>" by the processing expectation and ends up allocated.
+			ExpectResourceClaimAllocated(ctx, env.Client, pod.Namespace, fmt.Sprintf("%s-gpu", pod.Name), gpuDriver)
+		})
+	})
+
+	Context("Template (in-flight) device allocation (B)", func() {
+		It("should pack multiple pods onto one NodeClaim using distinct devices (B1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 2)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("claim-a", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("claim-b", test.ExactDeviceRequest("req", "gpu", 1)),
+			)
+			podA := draPod("gpu", "claim-a")
+			podB := draPod("gpu", "claim-b")
+			provisionDRA(podA, podB)
+
+			nodeA := ExpectScheduled(ctx, env.Client, podA)
+			nodeB := ExpectScheduled(ctx, env.Client, podB)
+			Expect(nodeA.Name).To(Equal(nodeB.Name), "both pods should share a single NodeClaim's two devices")
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+
+			devicesA := ExpectResourceClaimAllocated(ctx, env.Client, "default", "claim-a", gpuDriver)
+			devicesB := ExpectResourceClaimAllocated(ctx, env.Client, "default", "claim-b", gpuDriver)
+			Expect(devicesA).ToNot(ConsistOf(devicesB), "claims must not share a device")
+		})
+		It("should create a second NodeClaim when per-node device capacity is exhausted (B2)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("claim-a", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("claim-b", test.ExactDeviceRequest("req", "gpu", 1)),
+			)
+			podA := draPod("gpu", "claim-a")
+			podB := draPod("gpu", "claim-b")
+			provisionDRA(podA, podB)
+
+			nodeA := ExpectScheduled(ctx, env.Client, podA)
+			nodeB := ExpectScheduled(ctx, env.Client, podB)
+			Expect(nodeA.Name).ToNot(Equal(nodeB.Name), "single-device nodes can't host both pods")
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))
+		})
+	})
+
+	Context("Allocation modes & constraints (F)", func() {
+		It("should allocate every matching device in All mode (F1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 3)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.AllDeviceRequest("req", "gpu")))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
+			Expect(devices).To(HaveLen(3), "All mode should allocate every device on the instance type")
+		})
+		It("should satisfy a MatchAttribute constraint across two requests (F2)", func() {
+			// An instance type whose two GPU template devices share a concrete pcieRoot attribute. A claim with two
+			// requests and a MatchAttribute constraint must pick devices sharing that attribute value. This is an
+			// integration smoke test; deep constraint logic lives in the allocator unit tests. The attribute name must be
+			// a domain-qualified C identifier per the resource.k8s.io API.
+			const pcieRoot = gpuDriver + "/pcieRoot"
+			it := fake.NewInstanceType("gpu-it", fake.WithResourceSliceTemplates(
+				fake.ResourceSliceTemplate(gpuDriver, "gpu-it-pool",
+					fake.Device("gpu-0", map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{pcieRoot: test.StringAttribute("root-a")}),
+					fake.Device("gpu-1", map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{pcieRoot: test.StringAttribute("root-a")}),
+				),
+			))
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{it}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"},
+				Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{
+						test.ExactDeviceRequest("req-a", "gpu", 1),
+						test.ExactDeviceRequest("req-b", "gpu", 1),
+					},
+					Constraints: []resourcev1.DeviceConstraint{test.MatchAttributeConstraint(pcieRoot)},
+				}},
+			}))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
+			Expect(devices).To(HaveLen(2), "both requests are satisfied by attribute-sharing devices")
+		})
+	})
+
+	Context("dra-drivers annotation (G)", func() {
+		It("should list every driver whose devices were allocated (G1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuAndNICInstanceType("multi-it")}
+			ExpectApplied(ctx, env.Client, nodePool,
+				test.DeviceClassWithSelector("gpu", gpuDriver),
+				test.DeviceClassWithSelector("nic", nicDriver),
+			)
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("nic-claim", test.ExactDeviceRequest("req", "nic", 1)),
+			)
+			pod := draPodForClaims(
+				test.PodResourceClaimReference("gpu", "gpu-claim"),
+				test.PodResourceClaimReference("nic", "nic-claim"),
+			)
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(nodeClaims).To(HaveLen(1))
+			ExpectNodeClaimDRADrivers(nodeClaims[0], gpuDriver, nicDriver)
+		})
+	})
+
+	Context("Multiple provisioner runs (H)", func() {
+		It("should not double-allocate a device across runs (H1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("claim-a", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("claim-b", test.ExactDeviceRequest("req", "gpu", 1)),
+			)
+			// Run 1: provision for the first pod, allocating gpu-it's single device on its node.
+			podA := draPod("gpu", "claim-a")
+			provisionDRA(podA)
+			nodeA := ExpectScheduled(ctx, env.Client, podA)
+			devicesA := ExpectResourceClaimAllocated(ctx, env.Client, "default", "claim-a", gpuDriver)
+
+			// Initialize nodeA so its published in-cluster ResourceSlice (rather than templates) is gathered, and its
+			// allocated device is tracked by the deviceallocation controller as in-use.
+			ExpectMakeNodesInitialized(ctx, env.Client, env.Clock, nodeA)
+			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(nodeA))
+
+			// Run 2: a second pod must not reuse the device already published+allocated on nodeA; it provisions a new node.
+			podB := draPod("gpu", "claim-b")
+			provisionDRA(podB)
+			nodeB := ExpectScheduled(ctx, env.Client, podB)
+			Expect(nodeB.Name).ToNot(Equal(nodeA.Name))
+			devicesB := ExpectResourceClaimAllocated(ctx, env.Client, "default", "claim-b", gpuDriver)
+			Expect(devicesB).ToNot(ConsistOf(devicesA), "run 2 must not reallocate run 1's device")
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))
+		})
+		It("should treat a claim allocated in a prior run as already-allocated (H2)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 2)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("shared-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			// Run 1 allocates shared-claim and persists its status.
+			podA := draPod("gpu", "shared-claim")
+			provisionDRA(podA)
+			nodeA := ExpectScheduled(ctx, env.Client, podA)
+			devicesRun1 := ExpectResourceClaimAllocated(ctx, env.Client, "default", "shared-claim", gpuDriver)
+
+			// Run 2: a different pod references the same already-allocated claim. No new allocation/DFS occurs and the
+			// claim's allocation is unchanged.
+			podB := draPod("gpu", "shared-claim")
+			provisionDRA(podB)
+			ExpectScheduled(ctx, env.Client, podB)
+			devicesRun2 := ExpectResourceClaimAllocated(ctx, env.Client, "default", "shared-claim", gpuDriver)
+			Expect(devicesRun2).To(ConsistOf(devicesRun1), "claim allocation must be stable across runs")
+			_ = nodeA
+		})
+		It("should schedule on a later run once a missing claim is created (H3)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+
+			// Run 1: the referenced claim doesn't exist yet — pod is deferred, no NodeClaim.
+			pod := draPod("gpu", "late-claim")
+			ExpectApplied(ctx, env.Client, pod)
+			ExpectDeviceAllocationReconciled(ctx, env.Client, draController)
+			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, draProvisioner)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+
+			// Run 2: create the claim; the pod now schedules.
+			ExpectApplied(ctx, env.Client, test.ResourceClaim(resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "late-claim", Namespace: "default"},
+				Spec:       resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{test.ExactDeviceRequest("req", "gpu", 1)}}},
+			}))
+			provisionDRA(pod)
+			ExpectScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		})
+	})
+
+	Context("Enablement gating (N)", func() {
+		It("should reject DRA pods with a DRAError when IgnoreDRARequests is enabled (N1)", func() {
+			ctx = options.ToContext(ctx, test.Options(test.OptionsFields{IgnoreDRARequests: lo.ToPtr(true)}))
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			pod := draPod("gpu", "gpu-claim")
+			// The provisioner ignores DRA entirely under this flag, so the device controller isn't consulted.
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+	})
+
+	Context("Unsatisfiable / deferred (U)", func() {
+		It("should defer a pod whose ResourceClaim does not exist yet (U1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+
+			pod := draPod("gpu", "missing-claim")
+			ExpectApplied(ctx, env.Client, pod)
+			ExpectDeviceAllocationReconciled(ctx, env.Client, draController)
+			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, draProvisioner)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+		It("should fail to schedule when no instance type provides the requested device (U2)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("no-gpu-it")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+		It("should fail to schedule when the DeviceClass is missing (U3)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool)
+			// Note: no DeviceClass applied.
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+		It("should skip a claim-template reference whose generated name is nil (U4)", func() {
+			// A ResourceClaimTemplate reference whose status entry reports no generated claim name (claim generation was
+			// unnecessary). The allocator must skip it without panicking or allocating, and the pod schedules normally.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+
+			pod := draPodForClaims(test.PodResourceClaimTemplateReference("gpu", "gpu-template"))
+			// Pre-populate the status with a nil generated name so the processing expectation leaves it untouched and the
+			// allocator exercises the "no claim needed" skip branch.
+			pod.Status.ResourceClaimStatuses = []corev1.PodResourceClaimStatus{{Name: "gpu", ResourceClaimName: nil}}
+			provisionDRA(pod)
+
+			// No claim to allocate, so the pod schedules and no DRA driver annotation is recorded.
+			ExpectScheduled(ctx, env.Client, pod)
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(nodeClaims).To(HaveLen(1))
+			Expect(nodeClaims[0].Annotations).ToNot(HaveKey(v1.DRADriversAnnotationKey))
+		})
+	})
+
+	Context("Conflicts & contention (X)", func() {
+		It("should fail to schedule a pod whose two claims require incompatible zones (X1)", func() {
+			// plain-it provides no template devices, so both claims must be satisfied by the zoned in-cluster pools —
+			// forcing the genuine zone conflict (an instance type with a template GPU would let the gpu claim escape the
+			// zone constraint).
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("plain-it")}
+			ExpectApplied(ctx, env.Client, nodePool,
+				test.DeviceClassWithSelector("gpu", gpuDriver),
+				test.DeviceClassWithSelector("nic", nicDriver),
+			)
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("nic-claim", test.ExactDeviceRequest("req", "nic", 1)),
+			)
+			// The two pools are pinned to different zones, so no single NodeClaim can satisfy both claims.
+			ExpectApplied(ctx, env.Client,
+				zonedSlice("zoned-gpu-pool", gpuDriver, "test-zone-1", "zoned-gpu-0"),
+				zonedSlice("zoned-nic-pool", nicDriver, "test-zone-2", "zoned-nic-0"),
+			)
+			pod := draPodForClaims(
+				test.PodResourceClaimReference("gpu", "gpu-claim"),
+				test.PodResourceClaimReference("nic", "nic-claim"),
+			)
+			provisionDRA(pod)
+
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+		It("should fail when DRA prunes all instance types that otherwise fit (X3)", func() {
+			// Only the arm instance type provides the GPU device, but the pod requires amd64, so after DRA pruning no
+			// instance type satisfies both constraints.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				fake.NewInstanceType("arm-gpu-it",
+					fake.WithArchitecture("arm64"),
+					fake.WithResourceSliceTemplates(fake.ResourceSliceTemplate(gpuDriver, "arm-gpu-pool", fake.Devices("arm-gpu-0")...)),
+				),
+				fake.NewInstanceType("amd-no-gpu-it", fake.WithArchitecture("amd64")),
+			}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			pod := test.UnschedulablePod(test.PodOptions{
+				ResourceClaims:          []corev1.PodResourceClaim{test.PodResourceClaimReference("gpu", "gpu-claim")},
+				ContainerResourceClaims: []corev1.ResourceClaim{{Name: "gpu"}},
+				NodeRequirements: []corev1.NodeSelectorRequirement{
+					{Key: corev1.LabelArchStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"amd64"}},
+				},
+			})
+			provisionDRA(pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+	})
+
+	Context("Cross-cutting / regression (R)", func() {
+		It("should handle a mixed batch of DRA and non-DRA pods (R1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			draPod := draPod("gpu", "gpu-claim")
+			plainPod := test.UnschedulablePod()
+			provisionDRA(draPod, plainPod)
+
+			ExpectScheduled(ctx, env.Client, draPod)
+			ExpectScheduled(ctx, env.Client, plainPod)
+			ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
+		})
+		It("should surface DRA allocation metadata keyed by claim namespaced name (R2)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			pod := draPod("gpu", "gpu-claim")
+			ExpectApplied(ctx, env.Client, pod)
+			ExpectResourceClaimsProcessed(ctx, env.Client, pod)
+			ExpectDeviceAllocationReconciled(ctx, env.Client, draController)
+			results := ExpectProvisionedResults(ctx, env.Client, cluster, cloudProvider, draProvisioner, pod)
+			Expect(results.DRAClaimAllocationMetadata).To(HaveKey(types.NamespacedName{Namespace: "default", Name: "gpu-claim"}))
+		})
+	})
+
+	Context("In-cluster device allocation against existing nodes (C)", func() {
+		It("should bind to an existing initialized node whose published device satisfies the claim (C1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			// An existing initialized node publishes a GPU device in-cluster.
+			node := existingNode("gpu-it", true, corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("4Gi"), corev1.ResourcePods: resource.MustParse("10"),
+			})
+			ExpectApplied(ctx, env.Client, nodeLocalSlice(node, gpuDriver, "incluster-gpu-0"))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			// The pod schedules to the existing node; no new NodeClaim is created.
+			scheduled := ExpectScheduled(ctx, env.Client, pod)
+			Expect(scheduled.Name).To(Equal(node.Name))
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
+			Expect(devices).To(ConsistOf(NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
+		})
+		It("should prefer an existing node's published device over launching a new node (C2)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			// Existing node could satisfy the claim, and a new NodeClaim's template could too; the existing node wins.
+			node := existingNode("gpu-it", true, corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("4Gi"), corev1.ResourcePods: resource.MustParse("10"),
+			})
+			ExpectApplied(ctx, env.Client, nodeLocalSlice(node, gpuDriver, "incluster-gpu-0"))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			scheduled := ExpectScheduled(ctx, env.Client, pod)
+			Expect(scheduled.Name).To(Equal(node.Name))
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		})
+	})
+
+	Context("Topology propagation from node-local devices (D)", func() {
+		It("should tighten a new NodeClaim to the zone of a zoned in-cluster device (D1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+			// A cluster-managed pool restricts its device to test-zone-2.
+			ExpectApplied(ctx, env.Client, zonedSlice("zoned-gpu-pool", gpuDriver, "test-zone-2", "zoned-gpu-0"))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(nodeClaims).To(HaveLen(1))
+			// The zoned device's topology requirement is propagated onto the NodeClaim, constraining it to that zone.
+			req, found := lo.Find(nodeClaims[0].Spec.Requirements, func(r v1.NodeSelectorRequirementWithMinValues) bool {
+				return r.Key == corev1.LabelTopologyZone
+			})
+			Expect(found).To(BeTrue())
+			Expect(req.Values).To(ConsistOf("test-zone-2"))
+		})
+		It("should collapse a NodeClaim to the shared zone of two compatibly-zoned claims (D2)", func() {
+			// plain-it provides no templates, so both claims are satisfied by the zoned in-cluster pools and both
+			// contribute their zone requirement — exercising the intersection of two device topologies.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("plain-it")}
+			ExpectApplied(ctx, env.Client, nodePool,
+				test.DeviceClassWithSelector("gpu", gpuDriver),
+				test.DeviceClassWithSelector("nic", nicDriver),
+			)
+			ExpectApplied(ctx, env.Client,
+				test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)),
+				test.ResourceClaimForRequests("nic-claim", test.ExactDeviceRequest("req", "nic", 1)),
+			)
+			// Two cluster-managed pools, both constrained to test-zone-2 — their topology requirements intersect.
+			ExpectApplied(ctx, env.Client,
+				zonedSlice("zoned-gpu-pool", gpuDriver, "test-zone-2", "zoned-gpu-0"),
+				zonedSlice("zoned-nic-pool", nicDriver, "test-zone-2", "zoned-nic-0"),
+			)
+			pod := draPodForClaims(
+				test.PodResourceClaimReference("gpu", "gpu-claim"),
+				test.PodResourceClaimReference("nic", "nic-claim"),
+			)
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			nodeClaims := ExpectNodeClaims(ctx, env.Client)
+			Expect(nodeClaims).To(HaveLen(1))
+			req, found := lo.Find(nodeClaims[0].Spec.Requirements, func(r v1.NodeSelectorRequirementWithMinValues) bool {
+				return r.Key == corev1.LabelTopologyZone
+			})
+			Expect(found).To(BeTrue())
+			Expect(req.Values).To(ConsistOf("test-zone-2"))
+		})
+	})
+
+	Context("Cross-loop in-memory claim reuse (E)", func() {
+		It("should allocate a shared in-cluster claim once and reuse it within a single loop (E1)", func() {
+			// Two pods reference the same claim in one provisioning round. The claim is satisfied by a cluster-wide
+			// in-cluster device (not a template), so it is allocated once and the second pod reuses that in-memory
+			// allocation rather than re-running the DFS or allocating a second device.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("plain-it")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, clusterWideSlice("shared-gpu-pool", gpuDriver, "shared-gpu-0", "shared-gpu-1"))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("shared-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			podA := draPod("gpu", "shared-claim")
+			podB := draPod("gpu", "shared-claim")
+			provisionDRA(podA, podB)
+
+			ExpectScheduled(ctx, env.Client, podA)
+			ExpectScheduled(ctx, env.Client, podB)
+			// The shared claim is allocated exactly one device, shared by both pods.
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "shared-claim", gpuDriver)
+			Expect(devices).To(HaveLen(1))
+		})
+		It("should land a second pod on the same NodeClaim for a template-allocated shared claim (E2)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 2)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("shared-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			// Both pods reference the same claim within a single provisioning round. The claim is template-allocated
+			// (node-local), so the second pod must land on the same NodeClaim as the first.
+			podA := draPod("gpu", "shared-claim")
+			podB := draPod("gpu", "shared-claim")
+			provisionDRA(podA, podB)
+
+			nodeA := ExpectScheduled(ctx, env.Client, podA)
+			nodeB := ExpectScheduled(ctx, env.Client, podB)
+			Expect(nodeA.Name).To(Equal(nodeB.Name))
+			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		})
+	})
+
+	Context("Device availability via the deviceallocation controller (V)", func() {
+		It("should not reallocate a cluster-wide device held by a live pod (V2)", func() {
+			// No instance type provides template GPUs, so the only GPU devices are the two cluster-wide ones below. A
+			// live pod holds device-0, so a new claim must be given device-1 — never the held device.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("plain-it")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, clusterWideSlice("shared-gpu-pool", gpuDriver, "shared-gpu-0", "shared-gpu-1"))
+
+			// A live pod holds shared-gpu-0 via an allocated claim.
+			livePod := test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Name: "live-pod"}})
+			ExpectApplied(ctx, env.Client, livePod)
+			ExpectApplied(ctx, env.Client, allocatedClusterWideClaim("held-claim", "shared-gpu-pool", gpuDriver, "shared-gpu-0", podConsumer(livePod)))
+
+			newClaim := test.ResourceClaimForRequests("new-claim", test.ExactDeviceRequest("req", "gpu", 1))
+			ExpectApplied(ctx, env.Client, newClaim)
+			pod := draPod("gpu", "new-claim")
+			provisionDRA(pod)
+
+			ExpectScheduled(ctx, env.Client, pod)
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "new-claim", gpuDriver)
+			Expect(devices).To(ConsistOf("shared-gpu-pool/shared-gpu-1"), "must not reallocate the device held by a live pod")
+		})
+		It("should reclaim a cluster-wide device whose only consumer is a deleting pod (V1)", func() {
+			// A single cluster-wide GPU device, held by a pod on a deleting node. Because the consuming pod is on a
+			// node being deleted, the allocator treats the device as available and the new claim reclaims it.
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{fake.NewInstanceType("plain-it")}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, clusterWideSlice("shared-gpu-pool", gpuDriver, "shared-gpu-0"))
+
+			// Create a deleting node hosting the consuming pod, so the pod is sourced as a deleting-node pod in Schedule().
+			deletingNode := existingNode("plain-it", true, corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("4Gi"), corev1.ResourcePods: resource.MustParse("10"),
+			})
+			consumerPod := test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Name: "consumer-pod"}})
+			ExpectApplied(ctx, env.Client, consumerPod)
+			ExpectManualBinding(ctx, env.Client, consumerPod, deletingNode)
+			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(deletingNode))
+			ExpectApplied(ctx, env.Client, allocatedClusterWideClaim("held-claim", "shared-gpu-pool", gpuDriver, "shared-gpu-0", podConsumer(consumerPod)))
+
+			// Mark the node for deletion; its pod becomes a deleting-node pod that the provisioner reschedules.
+			Expect(env.Client.Delete(ctx, deletingNode)).To(Succeed())
+			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(deletingNode))
+
+			newClaim := test.ResourceClaimForRequests("new-claim", test.ExactDeviceRequest("req", "gpu", 1))
+			ExpectApplied(ctx, env.Client, newClaim)
+			pod := draPod("gpu", "new-claim")
+			provisionDRA(pod)
+
+			// The device was reclaimable (its only consumer is on a deleting node), so the new claim takes it.
+			ExpectScheduled(ctx, env.Client, pod)
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "new-claim", gpuDriver)
+			Expect(devices).To(ConsistOf("shared-gpu-pool/shared-gpu-0"))
+		})
+	})
+
+	Context("Slice sourcing / lifecycle edges (S)", func() {
+		It("should exclude published slices of an uninitialized node (S1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			// An uninitialized node has a published slice, but it must be excluded (the node is represented by templates).
+			node := existingNode("gpu-it", false, corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("4Gi"), corev1.ResourcePods: resource.MustParse("10"),
+			})
+			ExpectApplied(ctx, env.Client, nodeLocalSlice(node, gpuDriver, "incluster-gpu-0"))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			// The pod is satisfied via a new NodeClaim's template device (the uninitialized node's published slice is
+			// excluded), and the claim's allocated device comes from the new node's template pool, not the existing
+			// node's in-cluster pool.
+			scheduled := ExpectScheduled(ctx, env.Client, pod)
+			Expect(scheduled.Name).ToNot(Equal(node.Name))
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
+			Expect(devices).ToNot(ConsistOf(NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
+		})
+		It("should exclude slices owned by a node not in cluster state (S2)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			// A node-owned slice whose owning node was never registered in cluster state must be dropped from the pool.
+			orphanNode := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{corev1.LabelHostname: "orphan-node"},
+			}})
+			orphanNode.Name = "orphan-node"
+			ExpectApplied(ctx, env.Client, orphanNode)
+			orphanNode = ExpectExists(ctx, env.Client, orphanNode)
+			ExpectApplied(ctx, env.Client, nodeLocalSlice(orphanNode, gpuDriver, "orphan-gpu-0"))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			// The orphan slice is excluded, so the pod is satisfied via a new NodeClaim's template device.
+			ExpectScheduled(ctx, env.Client, pod)
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
+			Expect(devices).ToNot(ConsistOf(NodeLocalPoolName(gpuDriver, orphanNode.Name) + "/orphan-gpu-0"))
+		})
+	})
+
+	Context("Partially-initialized nodes (I)", func() {
+		It("should satisfy a pod via template devices for a pre-initialized node (I1)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("gpu-claim", test.ExactDeviceRequest("req", "gpu", 1)))
+
+			// A pre-initialized node exists with a published slice, but since it isn't initialized its devices come from
+			// templates and its published slice is excluded.
+			node := existingNode("gpu-it", false, corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("4Gi"), corev1.ResourcePods: resource.MustParse("10"),
+			})
+			ExpectApplied(ctx, env.Client, nodeLocalSlice(node, gpuDriver, "incluster-gpu-0"))
+
+			pod := draPod("gpu", "gpu-claim")
+			provisionDRA(pod)
+
+			// The pod schedules and its device is not the excluded published device.
+			ExpectScheduled(ctx, env.Client, pod)
+			devices := ExpectResourceClaimAllocated(ctx, env.Client, "default", "gpu-claim", gpuDriver)
+			Expect(devices).ToNot(ConsistOf(NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
+		})
+		It("should not double-count a node's devices across the uninitialized→initialized transition (I2)", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{gpuInstanceType("gpu-it", 1)}
+			ExpectApplied(ctx, env.Client, nodePool, test.DeviceClassWithSelector("gpu", gpuDriver))
+
+			// A pre-initialized node publishes its single GPU device in-cluster, but while uninitialized that device is
+			// represented by the node's template (published slice excluded).
+			node := existingNode("gpu-it", false, corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"), corev1.ResourceMemory: resource.MustParse("4Gi"), corev1.ResourcePods: resource.MustParse("10"),
+			})
+			ExpectApplied(ctx, env.Client, nodeLocalSlice(node, gpuDriver, "incluster-gpu-0"))
+
+			// Run 1 (uninitialized): the pod is satisfied via templates, not the existing node's published slice.
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("claim-a", test.ExactDeviceRequest("req", "gpu", 1)))
+			podA := draPod("gpu", "claim-a")
+			provisionDRA(podA)
+			ExpectScheduled(ctx, env.Client, podA)
+			devicesA := ExpectResourceClaimAllocated(ctx, env.Client, "default", "claim-a", gpuDriver)
+			Expect(devicesA).ToNot(ConsistOf(NodeLocalPoolName(gpuDriver, node.Name) + "/incluster-gpu-0"))
+
+			// Initialize the node so its published slice becomes authoritative for subsequent runs.
+			ExpectMakeNodesInitialized(ctx, env.Client, env.Clock, node)
+			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+
+			// Run 2 (initialized): the node's published device is now its single device. A second claim that requires the
+			// node's device must not double-count — since run 1 consumed the node's only template device via a separate
+			// NodeClaim, the published device is still free and can be allocated exactly once here.
+			ExpectApplied(ctx, env.Client, test.ResourceClaimForRequests("claim-b", test.ExactDeviceRequest("req", "gpu", 1)))
+			podB := draPod("gpu", "claim-b")
+			provisionDRA(podB)
+			ExpectScheduled(ctx, env.Client, podB)
+			devicesB := ExpectResourceClaimAllocated(ctx, env.Client, "default", "claim-b", gpuDriver)
+			Expect(devicesB).To(HaveLen(1), "the initialized node's published device is allocated exactly once")
+		})
+	})
+})

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -35,6 +35,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -47,12 +48,14 @@ import (
 
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	scheduler "sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
 	"sigs.k8s.io/karpenter/pkg/utils/daemonset"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodepoolutils "sigs.k8s.io/karpenter/pkg/utils/nodepool"
@@ -77,29 +80,31 @@ func WithReason(reason string) func(*LaunchOptions) {
 
 // Provisioner waits for enqueued pods, batches them, creates capacity and binds the pods to the capacity.
 type Provisioner struct {
-	cloudProvider  cloudprovider.CloudProvider
-	kubeClient     client.Client
-	batcher        *Batcher[types.UID]
-	volumeTopology *scheduler.VolumeTopology
-	cluster        *state.Cluster
-	recorder       events.Recorder
-	cm             *pretty.ChangeMonitor
-	clock          clock.Clock
+	cloudProvider              cloudprovider.CloudProvider
+	kubeClient                 client.Client
+	batcher                    *Batcher[types.UID]
+	volumeTopology             *scheduler.VolumeTopology
+	cluster                    *state.Cluster
+	recorder                   events.Recorder
+	cm                         *pretty.ChangeMonitor
+	clock                      clock.Clock
+	deviceAllocationController *deviceallocation.Controller
 }
 
 func NewProvisioner(kubeClient client.Client, recorder events.Recorder,
 	cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster,
-	clock clock.Clock,
+	clock clock.Clock, deviceAllocationController *deviceallocation.Controller,
 ) *Provisioner {
 	p := &Provisioner{
-		batcher:        NewBatcher[types.UID](clock),
-		cloudProvider:  cloudProvider,
-		kubeClient:     kubeClient,
-		volumeTopology: scheduler.NewVolumeTopology(kubeClient),
-		cluster:        cluster,
-		recorder:       recorder,
-		cm:             pretty.NewChangeMonitor(),
-		clock:          clock,
+		batcher:                    NewBatcher[types.UID](clock),
+		cloudProvider:              cloudProvider,
+		kubeClient:                 kubeClient,
+		volumeTopology:             scheduler.NewVolumeTopology(kubeClient),
+		cluster:                    cluster,
+		recorder:                   recorder,
+		cm:                         pretty.NewChangeMonitor(),
+		clock:                      clock,
+		deviceAllocationController: deviceAllocationController,
 	}
 	return p
 }
@@ -257,6 +262,7 @@ func (p *Provisioner) NewScheduler(
 	ctx context.Context,
 	pods []*corev1.Pod,
 	stateNodes []*state.StateNode,
+	deletingPodUIDs sets.Set[types.UID],
 	opts ...scheduler.Options,
 ) (*scheduler.Scheduler, error) {
 	nodePools, err := nodepoolutils.ListManaged(ctx, p.kubeClient, p.cloudProvider)
@@ -320,8 +326,25 @@ func (p *Provisioner) NewScheduler(
 	if err != nil {
 		return nil, fmt.Errorf("getting daemon pods, %w", err)
 	}
+
+	// Build the DRA device allocator for this scheduling loop. Slice/device gathering happens here (rather than in the
+	// scheduler) so the same filtering can be reused by other schedulers, e.g. disruption. When DRA support is disabled,
+	// the allocator is left nil and the scheduler short-circuits DRA pods.
+	var allocator *dynamicresources.Allocator
+	if !options.FromContext(ctx).IgnoreDRARequests {
+		inClusterSlices, err := p.gatherResourceSlices(ctx, stateNodes)
+		if err != nil {
+			return nil, fmt.Errorf("gathering resourceslices, %w", err)
+		}
+		allocatedDevices, err := p.gatherAllocatedDevices(ctx, deletingPodUIDs)
+		if err != nil {
+			return nil, fmt.Errorf("gathering allocated devices, %w", err)
+		}
+		allocator = dynamicresources.NewAllocator(inClusterSlices, allocatedDevices, dynamicresources.BuildAttributeBindings(instanceTypes), p.kubeClient)
+	}
+
 	// Pass volumeReqs to scheduler - added to nodeRequirements for NodeClaim zone selection
-	return scheduler.NewScheduler(ctx, p.kubeClient, nodePools, p.cluster, stateNodes, topology, instanceTypes, daemonSetPods, p.recorder, p.clock, volumeReqs, opts...), nil
+	return scheduler.NewScheduler(ctx, p.kubeClient, nodePools, p.cluster, stateNodes, topology, instanceTypes, daemonSetPods, p.recorder, p.clock, volumeReqs, allocator, opts...), nil
 }
 
 func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
@@ -359,6 +382,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 	if len(pods) == 0 {
 		return scheduler.Results{}, nil
 	}
+	deletingPodUIDs := sets.New(lo.Map(deletingNodePods, func(p *corev1.Pod, _ int) types.UID { return p.UID })...)
 	log.FromContext(ctx).V(1).WithValues("pending-pods", len(pendingPods), "deleting-pods", len(deletingNodePods)).Info("computing scheduling decision for provisionable pod(s)")
 
 	opts := []scheduler.Options{
@@ -373,6 +397,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (scheduler.Results, error) {
 		ctx,
 		pods,
 		nodes.Active(),
+		deletingPodUIDs,
 		opts...,
 	)
 	if err != nil {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -340,7 +340,7 @@ func (p *Provisioner) NewScheduler(
 		if err != nil {
 			return nil, fmt.Errorf("gathering allocated devices, %w", err)
 		}
-		allocator = dynamicresources.NewAllocator(inClusterSlices, allocatedDevices, dynamicresources.BuildAttributeBindings(instanceTypes), p.kubeClient)
+		allocator = dynamicresources.NewAllocator(inClusterSlices, allocatedDevices, dynamicresources.BuildAttributeBindings(instanceTypes), p.kubeClient, deletingPodUIDs)
 	}
 
 	// Pass volumeReqs to scheduler - added to nodeRequirements for NodeClaim zone selection

--- a/pkg/controllers/provisioning/scheduling/dra.go
+++ b/pkg/controllers/provisioning/scheduling/dra.go
@@ -1,0 +1,211 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+	"fmt"
+	"unique"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
+)
+
+// draNodeClaim adapts a scheduling *NodeClaim (in-flight or new) to the allocator's NodeClaim interface. An in-flight
+// NodeClaim is a superposition of candidate instance types; ResourceSlices() therefore surfaces the template devices
+// for every candidate instance type.
+type draNodeClaim struct {
+	nc *NodeClaim
+}
+
+func (d *draNodeClaim) ID() dynamicresources.NodeClaimID {
+	// The hostname placeholder is unique per NodeClaim within a scheduling loop and stable across CanAdd/Add/Release.
+	return unique.Make(d.nc.hostname)
+}
+
+func (d *draNodeClaim) NodeName() string {
+	// In-flight and new NodeClaims have no concrete node, so node-name-pinned published slices never apply.
+	return ""
+}
+
+func (d *draNodeClaim) NodePoolID() dynamicresources.NodePoolID {
+	return unique.Make(d.nc.NodePoolName)
+}
+
+func (d *draNodeClaim) Requirements() scheduling.Requirements {
+	return d.nc.Requirements
+}
+
+func (d *draNodeClaim) InstanceTypes() []dynamicresources.InstanceTypeID {
+	return lo.Map(d.nc.InstanceTypeOptions, func(it *cloudprovider.InstanceType, _ int) dynamicresources.InstanceTypeID {
+		return unique.Make(it.Name)
+	})
+}
+
+func (d *draNodeClaim) ResourceSlices() map[dynamicresources.InstanceTypeID][]dynamicresources.ResourceSlice {
+	slices := map[dynamicresources.InstanceTypeID][]dynamicresources.ResourceSlice{}
+	for _, it := range d.nc.InstanceTypeOptions {
+		slices[unique.Make(it.Name)] = templateSlicesForInstanceType(it)
+	}
+	return slices
+}
+
+// draExistingNode adapts a scheduling *ExistingNode to the allocator's NodeClaim interface. An existing node has a
+// single known instance type. Once initialized, its devices are published as in-cluster ResourceSlices, so
+// ResourceSlices() is empty. While uninitialized (pre-initialized), template devices are the source of truth, so
+// ResourceSlices() returns the full template set for the node's instance type.
+type draExistingNode struct {
+	en *ExistingNode
+	// instanceType is the resolved cloud provider instance type for the node, or nil if it could not be resolved
+	// (e.g. an unmanaged node, or an instance type no longer offered by the NodePool).
+	instanceType *cloudprovider.InstanceType
+}
+
+func (d *draExistingNode) ID() dynamicresources.NodeClaimID {
+	return unique.Make(d.en.ProviderID())
+}
+
+func (d *draExistingNode) NodeName() string {
+	// Published ResourceSlices pinned via spec.nodeName are accessible only from the node with this name.
+	if d.en.Node != nil {
+		return d.en.Node.Name
+	}
+	return ""
+}
+
+func (d *draExistingNode) NodePoolID() dynamicresources.NodePoolID {
+	return unique.Make(d.en.Labels()[v1.NodePoolLabelKey])
+}
+
+func (d *draExistingNode) Requirements() scheduling.Requirements {
+	return d.en.requirements
+}
+
+func (d *draExistingNode) InstanceTypes() []dynamicresources.InstanceTypeID {
+	return []dynamicresources.InstanceTypeID{unique.Make(d.en.Labels()[corev1.LabelInstanceTypeStable])}
+}
+
+func (d *draExistingNode) ResourceSlices() map[dynamicresources.InstanceTypeID][]dynamicresources.ResourceSlice {
+	// Initialized nodes have their devices published in-cluster; uninitialized nodes are represented by templates.
+	if d.en.Initialized() || d.instanceType == nil {
+		return map[dynamicresources.InstanceTypeID][]dynamicresources.ResourceSlice{}
+	}
+	return map[dynamicresources.InstanceTypeID][]dynamicresources.ResourceSlice{
+		unique.Make(d.instanceType.Name): templateSlicesForInstanceType(d.instanceType),
+	}
+}
+
+func templateSlicesForInstanceType(it *cloudprovider.InstanceType) []dynamicresources.ResourceSlice {
+	return lo.Map(it.DynamicResources.ResourceSliceTemplates, func(t *cloudprovider.ResourceSliceTemplate, _ int) dynamicresources.ResourceSlice {
+		return dynamicresources.NewTemplateSlice(t)
+	})
+}
+
+// instanceTypeForNode resolves the cloud provider instance type backing a node from the scheduler's per-NodePool
+// instance type set. Returns nil when the node is unmanaged or its instance type is not in the current set.
+func (s *Scheduler) instanceTypeForNode(n *state.StateNode) *cloudprovider.InstanceType {
+	itName := n.Labels()[corev1.LabelInstanceTypeStable]
+	nodePoolName := n.Labels()[v1.NodePoolLabelKey]
+	if itName == "" || nodePoolName == "" {
+		return nil
+	}
+	return lo.FindOrElse(s.instanceTypes[nodePoolName], nil, func(it *cloudprovider.InstanceType) bool {
+		return it.Name == itName
+	})
+}
+
+// draDriversForNodeClaim returns the sorted set of DRA driver names whose devices were allocated to pods scheduled to
+// the given NodeClaim. It reads the allocator's per-claim allocation metadata, which records the allocated devices
+// (and therefore their drivers) keyed by the source NodeClaim. Returns nil when DRA is disabled or no devices were
+// allocated for the NodeClaim.
+func (s *Scheduler) draDriversForNodeClaim(nc *NodeClaim) []string {
+	if s.allocator == nil {
+		return nil
+	}
+	nodeClaimID := unique.Make(nc.hostname)
+	drivers := sets.New[string]()
+	for _, meta := range s.allocator.ResourceClaimAllocationMetadata() {
+		if meta.NodeClaimID != nodeClaimID {
+			continue
+		}
+		for _, deviceResults := range meta.Devices {
+			for _, deviceResult := range deviceResults {
+				drivers.Insert(deviceResult.DeviceID.Driver.Value())
+			}
+		}
+	}
+	return sets.List(drivers)
+}
+
+// resolvePodClaims resolves the ResourceClaim objects referenced by a pod into concrete *resourcev1.ResourceClaim
+// objects, memoizing lookups for the duration of the scheduling loop. Claims that don't need to be generated (a
+// ResourceClaimTemplate whose status entry has a nil ResourceClaimName) are skipped. Returns an error if a referenced
+// claim has not yet been created, so the pod is deferred to a subsequent loop.
+func (s *Scheduler) resolvePodClaims(ctx context.Context, pod *corev1.Pod) ([]*resourcev1.ResourceClaim, error) {
+	claims := make([]*resourcev1.ResourceClaim, 0, len(pod.Spec.ResourceClaims))
+	for i := range pod.Spec.ResourceClaims {
+		pc := &pod.Spec.ResourceClaims[i]
+		claimName, ok := resourceClaimName(pod, pc)
+		if !ok {
+			// The claim was not generated (e.g. a template whose status name is nil); nothing to allocate for it.
+			continue
+		}
+		key := types.NamespacedName{Namespace: pod.Namespace, Name: claimName}
+		claim, ok := s.cachedResourceClaims[key]
+		if !ok {
+			claim = &resourcev1.ResourceClaim{}
+			if err := s.kubeClient.Get(ctx, key, claim); err != nil {
+				if errors.IsNotFound(err) {
+					return nil, fmt.Errorf("resourceclaim %q not found", key)
+				}
+				return nil, fmt.Errorf("getting resourceclaim %q, %w", key, err)
+			}
+			s.cachedResourceClaims[key] = claim
+		}
+		claims = append(claims, claim)
+	}
+	return claims, nil
+}
+
+// resourceClaimName resolves the name of the ResourceClaim backing a pod's claim reference. A direct
+// ResourceClaimName is used as-is; otherwise the generated name is looked up from the pod's
+// status.resourceClaimStatuses. The second return is false when no claim needs to be allocated.
+func resourceClaimName(pod *corev1.Pod, pc *corev1.PodResourceClaim) (string, bool) {
+	if pc.ResourceClaimName != nil {
+		return *pc.ResourceClaimName, true
+	}
+	for i := range pod.Status.ResourceClaimStatuses {
+		status := &pod.Status.ResourceClaimStatuses[i]
+		if status.Name == pc.Name {
+			if status.ResourceClaimName == nil {
+				return "", false
+			}
+			return *status.ResourceClaimName, true
+		}
+	}
+	return "", false
+}

--- a/pkg/controllers/provisioning/scheduling/dra_internal_test.go
+++ b/pkg/controllers/provisioning/scheduling/dra_internal_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"unique"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+)
+
+var _ = Describe("DRA Scheduling Internals", func() {
+	Describe("resourceClaimName", func() {
+		It("should use a direct ResourceClaimName", func() {
+			pod := &corev1.Pod{}
+			claim := corev1.PodResourceClaim{Name: "ref", ResourceClaimName: lo.ToPtr("claim-a")}
+			name, ok := resourceClaimName(pod, &claim)
+			Expect(ok).To(BeTrue())
+			Expect(name).To(Equal("claim-a"))
+		})
+		It("should resolve a template's generated name from pod status", func() {
+			pod := &corev1.Pod{Status: corev1.PodStatus{ResourceClaimStatuses: []corev1.PodResourceClaimStatus{
+				{Name: "ref", ResourceClaimName: lo.ToPtr("generated-a")},
+			}}}
+			claim := corev1.PodResourceClaim{Name: "ref"}
+			name, ok := resourceClaimName(pod, &claim)
+			Expect(ok).To(BeTrue())
+			Expect(name).To(Equal("generated-a"))
+		})
+		It("should skip a template whose generated name is nil", func() {
+			pod := &corev1.Pod{Status: corev1.PodStatus{ResourceClaimStatuses: []corev1.PodResourceClaimStatus{
+				{Name: "ref", ResourceClaimName: nil},
+			}}}
+			claim := corev1.PodResourceClaim{Name: "ref"}
+			_, ok := resourceClaimName(pod, &claim)
+			Expect(ok).To(BeFalse())
+		})
+		It("should skip when no matching status entry exists", func() {
+			pod := &corev1.Pod{}
+			claim := corev1.PodResourceClaim{Name: "ref"}
+			_, ok := resourceClaimName(pod, &claim)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("draNodeClaim adapter", func() {
+		var it1, it2 *cloudprovider.InstanceType
+		var nc *NodeClaim
+
+		BeforeEach(func() {
+			it1 = &cloudprovider.InstanceType{
+				Name: "it-1",
+				DynamicResources: cloudprovider.DynamicResources{
+					ResourceSliceTemplates: []*cloudprovider.ResourceSliceTemplate{{Driver: unique.Make("driver-a")}},
+				},
+			}
+			it2 = &cloudprovider.InstanceType{Name: "it-2"}
+			nc = &NodeClaim{hostname: "hostname-1"}
+			nc.NodePoolName = "np-a"
+			nc.Requirements = scheduling.NewRequirements()
+			nc.InstanceTypeOptions = cloudprovider.InstanceTypes{it1, it2}
+		})
+
+		It("should map identity, nodepool, and instance types", func() {
+			adapter := &draNodeClaim{nc: nc}
+			Expect(adapter.ID()).To(Equal(unique.Make("hostname-1")))
+			Expect(adapter.NodePoolID()).To(Equal(unique.Make("np-a")))
+			its := lo.Map(adapter.InstanceTypes(), func(id unique.Handle[string], _ int) string { return id.Value() })
+			Expect(its).To(ConsistOf("it-1", "it-2"))
+		})
+		It("should expose template slices per instance type", func() {
+			adapter := &draNodeClaim{nc: nc}
+			slices := adapter.ResourceSlices()
+			Expect(slices[unique.Make("it-1")]).To(HaveLen(1))
+			Expect(slices[unique.Make("it-2")]).To(BeEmpty())
+		})
+	})
+
+	Describe("draExistingNode adapter", func() {
+		var it *cloudprovider.InstanceType
+
+		BeforeEach(func() {
+			it = &cloudprovider.InstanceType{
+				Name: "it-1",
+				DynamicResources: cloudprovider.DynamicResources{
+					ResourceSliceTemplates: []*cloudprovider.ResourceSliceTemplate{{Driver: unique.Make("driver-a")}},
+				},
+			}
+		})
+
+		It("should return no template slices for an initialized node", func() {
+			adapter := draExistingNodeForTest(true, it)
+			Expect(adapter.ResourceSlices()).To(BeEmpty())
+		})
+		It("should return the full template set for a pre-initialized node", func() {
+			adapter := draExistingNodeForTest(false, it)
+			Expect(adapter.ResourceSlices()[unique.Make("it-1")]).To(HaveLen(1))
+		})
+		It("should return no template slices for a pre-initialized node with an unresolved instance type", func() {
+			adapter := draExistingNodeForTest(false, nil)
+			Expect(adapter.ResourceSlices()).To(BeEmpty())
+		})
+	})
+})
+
+// draExistingNodeForTest builds a draExistingNode backed by a StateNode whose initialization state and labels are set
+// for exercising the adapter's ResourceSlices() behavior.
+func draExistingNodeForTest(initialized bool, it *cloudprovider.InstanceType) *draExistingNode {
+	labels := map[string]string{
+		corev1.LabelInstanceTypeStable: "it-1",
+		v1.NodePoolLabelKey:            "np-a",
+	}
+	if initialized {
+		labels[v1.NodeInitializedLabelKey] = "true"
+	}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", Labels: labels}}
+	nodeClaim := &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Labels: labels}}
+	en := &ExistingNode{StateNode: &state.StateNode{Node: node, NodeClaim: nodeClaim}, instanceType: it}
+	en.requirements = scheduling.NewLabelRequirements(labels)
+	return &draExistingNode{en: en, instanceType: it}
+}

--- a/pkg/controllers/provisioning/scheduling/existingnode.go
+++ b/pkg/controllers/provisioning/scheduling/existingnode.go
@@ -17,12 +17,15 @@ limitations under the License.
 package scheduling
 
 import (
+	"context"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
 	"sigs.k8s.io/karpenter/pkg/utils/resources"
 )
 
@@ -36,9 +39,12 @@ type ExistingNode struct {
 	remainingResources      v1.ResourceList
 	requirements            scheduling.Requirements
 	isUnderConsolidateAfter bool
+	// instanceType is the resolved cloud provider instance type backing the node, used to source DRA template devices
+	// for uninitialized nodes. It is nil for unmanaged nodes or when the node's instance type is not in the current set.
+	instanceType *cloudprovider.InstanceType
 }
 
-func NewExistingNode(n *state.StateNode, topology *Topology, taints []v1.Taint, daemonResources v1.ResourceList, isUnderConsolidateAfter bool) *ExistingNode {
+func NewExistingNode(n *state.StateNode, topology *Topology, taints []v1.Taint, daemonResources v1.ResourceList, instanceType *cloudprovider.InstanceType, isUnderConsolidateAfter bool) *ExistingNode {
 	// The state node passed in here must be a deep copy from cluster state as we modify it
 	// the remaining daemonResources to schedule are the total daemonResources minus what has already scheduled
 	resources.SubtractFrom(daemonResources, n.DaemonSetRequests())
@@ -60,6 +66,7 @@ func NewExistingNode(n *state.StateNode, topology *Topology, taints []v1.Taint, 
 		remainingResources:      resources.Subtract(available, daemonResources),
 		requirements:            scheduling.NewLabelRequirements(n.Labels()),
 		isUnderConsolidateAfter: isUnderConsolidateAfter,
+		instanceType:            instanceType,
 	}
 	node.requirements.Add(scheduling.NewRequirement(v1.LabelHostname, v1.NodeSelectorOpIn, n.HostName()))
 	topology.Register(v1.LabelHostname, n.HostName())
@@ -69,27 +76,29 @@ func NewExistingNode(n *state.StateNode, topology *Topology, taints []v1.Taint, 
 // CanAdd returns whether the pod can be added to the ExistingNode
 // based on the taints/tolerations, volume requirements, host port compatibility,
 // requirements, resources, and topology requirements
-func (n *ExistingNode) CanAdd(pod *v1.Pod, podData *PodData, volumes scheduling.Volumes) (updatedRequirements scheduling.Requirements, err error) {
+//
+//nolint:gocyclo
+func (n *ExistingNode) CanAdd(ctx context.Context, pod *v1.Pod, podData *PodData, volumes scheduling.Volumes, allocator *dynamicresources.Allocator) (updatedRequirements scheduling.Requirements, allocationResult *dynamicresources.AllocationResult, err error) {
 	// Check Taints
 	if err := scheduling.Taints(n.cachedTaints).ToleratesPod(pod); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// determine the host ports that will be used if the pod schedules
 	hostPorts := scheduling.GetHostPorts(pod)
 	if err = n.VolumeUsage().ExceedsLimits(volumes); err != nil {
-		return nil, fmt.Errorf("checking volume usage, %w", err)
+		return nil, nil, fmt.Errorf("checking volume usage, %w", err)
 	}
 	if err = n.HostPortUsage().Conflicts(pod, hostPorts); err != nil {
-		return nil, fmt.Errorf("checking host port usage, %w", err)
+		return nil, nil, fmt.Errorf("checking host port usage, %w", err)
 	}
 	// check resource requests first since that's a pretty likely reason the pod won't schedule on an in-flight
 	// node, which at this point can't be increased in size
 	if !resources.Fits(podData.Requests, n.remainingResources) {
-		return nil, fmt.Errorf("exceeds node resources")
+		return nil, nil, fmt.Errorf("exceeds node resources")
 	}
 	// Check NodeClaim Affinity Requirements
 	if err = n.requirements.Compatible(podData.Requirements); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// avoid creating our temp set of requirements until after we've ensured that at least
 	// the pod is compatible
@@ -110,9 +119,23 @@ func (n *ExistingNode) CanAdd(pod *v1.Pod, podData *PodData, volumes scheduling.
 			lastErr = err
 			continue
 		}
-		return reqs, nil
+		// Simulate DRA device allocation against this existing node. The node's requirements are immutable, so we don't
+		// merge the result's requirements back in (the allocator validates topology compatibility internally); we only
+		// need to confirm the claims can be satisfied and carry the allocation handle to commit on Add.
+		if podData.HasResourceClaimRequests && allocator != nil {
+			if podData.ResourceClaimErr != nil {
+				return nil, nil, podData.ResourceClaimErr
+			}
+			result, err := allocator.Allocate(ctx, &draExistingNode{en: n, instanceType: n.instanceType}, podData.ResourceClaims)
+			if err != nil {
+				lastErr = fmt.Errorf("allocating dynamic resources, %w", err)
+				continue
+			}
+			return reqs, result, nil
+		}
+		return reqs, nil, nil
 	}
-	return nil, lastErr
+	return nil, nil, lastErr
 }
 
 // tryVolumeAlternative attempts to add a pod with a specific set of volume requirements,
@@ -146,7 +169,7 @@ func (n *ExistingNode) tryVolumeAlternative(pod *v1.Pod, podData *PodData, baseR
 
 // Add updates the ExistingNode to schedule the pod to this ExistingNode, updating
 // the ExistingNode with new requirements and volumes based on the pod scheduling
-func (n *ExistingNode) Add(pod *v1.Pod, podData *PodData, nodeRequirements scheduling.Requirements, volumes scheduling.Volumes) {
+func (n *ExistingNode) Add(ctx context.Context, pod *v1.Pod, podData *PodData, nodeRequirements scheduling.Requirements, volumes scheduling.Volumes, allocationResult *dynamicresources.AllocationResult) {
 	// Update node
 	n.Pods = append(n.Pods, pod)
 	resources.SubtractFrom(n.remainingResources, podData.Requests)
@@ -154,4 +177,9 @@ func (n *ExistingNode) Add(pod *v1.Pod, podData *PodData, nodeRequirements sched
 	n.topology.Record(pod, n.cachedTaints, nodeRequirements)
 	n.HostPortUsage().Add(pod, scheduling.GetHostPorts(pod))
 	n.VolumeUsage().Add(pod, volumes)
+	// Commit the DRA device allocation now that the placement decision is finalized. The Allocation handle is nil when
+	// there were no new device allocations to commit (e.g. every claim was already allocated in-cluster).
+	if allocationResult != nil && allocationResult.Allocation != nil {
+		allocationResult.Allocation.Commit(ctx)
+	}
 }

--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -562,48 +562,46 @@ var _ = Describe("Instance Type Selection", func() {
 	})
 	It("should schedule on cheaper on-demand instance even when spot price ordering would place other instance types first", func() {
 		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name:             "test-instance1",
-				Architecture:     "amd64",
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			fake.NewInstanceType("test-instance1",
+				fake.WithArchitecture("amd64"),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-				Offerings: []*cloudprovider.Offering{
-					{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
 						Price:        1.0,
 					},
-					{
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1a"}),
 						Price:        0.2,
 					},
-				},
-			}),
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name:             "test-instance2",
-				Architecture:     "amd64",
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				),
+			),
+			fake.NewInstanceType("test-instance2",
+				fake.WithArchitecture("amd64"),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-				Offerings: []*cloudprovider.Offering{
-					{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a"}),
 						Price:        1.3,
 					},
-					{
+					cloudprovider.Offering{
 						Available:    true,
 						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1a"}),
 						Price:        0.1,
 					},
-				},
-			}),
+				),
+			),
 		}
 		nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirementWithMinValues{
 			{
@@ -623,40 +621,36 @@ var _ = Describe("Instance Type Selection", func() {
 		It("should schedule respecting the minValues from instance-type requirements", func() {
 			var instanceTypes []*cloudprovider.InstanceType
 			// Create fake InstanceTypeOptions where one instances can fit 2 pods and another one can fit only 1 pod.
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1))
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts2))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on instance-type requirement.
@@ -700,58 +694,54 @@ var _ = Describe("Instance Type Selection", func() {
 			// custom key that will help us with numerical values to be used for Gt operator
 			instanceGeneration := "karpenter/numerical-value"
 			var instanceTypes []*cloudprovider.InstanceType
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			opts3 := fake.InstanceTypeOptions{
-				Name:             "instance-type-3",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "3")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-3",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts3.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.2,
-				},
-			}
-
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts1, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts2, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "3")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts3, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "4")))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.2,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "4")),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on instance generation using Gt operator in requirement.
@@ -795,40 +785,38 @@ var _ = Describe("Instance Type Selection", func() {
 			// custom key that will help us with numerical values to be used for Gt operator
 			instanceGeneration := "karpenter/numerical-value"
 			var instanceTypes []*cloudprovider.InstanceType
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts1, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts2, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "3")))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "3")),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on instance generation using Gt operator in requirement.
@@ -883,57 +871,54 @@ var _ = Describe("Instance Type Selection", func() {
 			// custom key that will help us with numerical values to be used for Lt operator
 			instanceGeneration := "karpenter/numerical-value"
 			var instanceTypes []*cloudprovider.InstanceType
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("2"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			opts3 := fake.InstanceTypeOptions{
-				Name:             "instance-type-3",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "3")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-3",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts3.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.2,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts1, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts2, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "3")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts3, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "4")))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.2,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "4")),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on instance generation using Lt operator in requirement.
@@ -977,40 +962,38 @@ var _ = Describe("Instance Type Selection", func() {
 			// custom key that will help us with numerical values to be used for Lt operator
 			instanceGeneration := "karpenter/numerical-value"
 			var instanceTypes []*cloudprovider.InstanceType
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("2"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.2,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts1, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts2, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "4")))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.2,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "4")),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on instance generation using Lt operator in requirement.
@@ -1045,57 +1028,51 @@ var _ = Describe("Instance Type Selection", func() {
 		})
 		It("should schedule considering the max of the minValues of In and NotIn operators in the instance-type requirements", func() {
 			var instanceTypes []*cloudprovider.InstanceType
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("2"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			opts3 := fake.InstanceTypeOptions{
-				Name:             "instance-type-3",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-3",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts3.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.2,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1))
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts2))
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts3))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.2,
+					},
+				),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on both In and NotIn operators for instance-type requirement.
@@ -1145,74 +1122,70 @@ var _ = Describe("Instance Type Selection", func() {
 			// custom key that will help us with numerical values to be used for Gt operator
 			instanceGeneration := "karpenter/numerical-value"
 			var instanceTypes []*cloudprovider.InstanceType
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			opts3 := fake.InstanceTypeOptions{
-				Name:             "instance-type-3",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "3")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-3",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts3.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.2,
-				},
-			}
-			opts4 := fake.InstanceTypeOptions{
-				Name:             "instance-type-4",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.2,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "4")),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-4",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts4.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.2,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts1, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "2")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts2, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "3")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts3, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "4")))
-			instanceTypes = append(instanceTypes, fake.NewInstanceTypeWithCustomRequirement(opts3, scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "5")))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.2,
+					},
+				),
+				fake.WithRequirements(scheduler.NewRequirement(instanceGeneration, corev1.NodeSelectorOpIn, "5")),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on instance generation using Gt operator in requirement.
@@ -1288,40 +1261,36 @@ var _ = Describe("Instance Type Selection", func() {
 		It("schedule should fail if minimum number of InstanceTypes is not met as per the minValues in the requirement after truncation", func() {
 			var instanceTypes []*cloudprovider.InstanceType
 			// Create fake InstanceTypeOptions where one instances can fit 2 pods and another one can fit only 1 pod.
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1))
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts2))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+			))
 			// We have the required InstanceTypes that meet the minValues requirement.
 			cloudProvider.InstanceTypes = instanceTypes
 			// The truncation is changed from the default to 1 for the ease of testing.
@@ -1362,40 +1331,36 @@ var _ = Describe("Instance Type Selection", func() {
 		It("should schedule and pick the max of minValues of InstanceTypes if multiple operators are used for the same requirement.", func() {
 			// Create fake InstanceTypeOptions where one instances can fit 2 pods and another one can fit only 1 pod.
 			var instanceTypes []*cloudprovider.InstanceType
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1))
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts2))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on instance-type requirement with multiple operators
@@ -1445,40 +1410,36 @@ var _ = Describe("Instance Type Selection", func() {
 		It("should schedule and respect multiple requirement keys with minValues", func() {
 			// Create fake InstanceTypeOptions where one instances can fit 2 pods and another one can fit only 1 pod.
 			var instanceTypes []*cloudprovider.InstanceType
-			opts1 := fake.InstanceTypeOptions{
-				Name:             "instance-type-1",
-				Architecture:     v1.ArchitectureArm64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+				fake.WithArchitecture(v1.ArchitectureArm64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-				},
-			}
-			opts1.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        0.52,
-				},
-			}
-			opts2 := fake.InstanceTypeOptions{
-				Name:             "instance-type-2",
-				Architecture:     v1.ArchitectureAmd64,
-				OperatingSystems: sets.New(string(corev1.Linux)),
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        0.52,
+					},
+				),
+			))
+			instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-2",
+				fake.WithArchitecture(v1.ArchitectureAmd64),
+				fake.WithOperatingSystems(string(corev1.Linux)),
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
-				},
-			}
-			opts2.Offerings = []*cloudprovider.Offering{
-				{
-					Available:    true,
-					Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
-					Price:        1.0,
-				},
-			}
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1))
-			instanceTypes = append(instanceTypes, fake.NewInstanceType(opts2))
+				}),
+				fake.WithOfferings(
+					cloudprovider.Offering{
+						Available:    true,
+						Requirements: scheduler.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
+						Price:        1.0,
+					},
+				),
+			))
 			cloudProvider.InstanceTypes = instanceTypes
 
 			// Define NodePool that has minValues on multiple requirements

--- a/pkg/controllers/provisioning/scheduling/nodeclaim.go
+++ b/pkg/controllers/provisioning/scheduling/nodeclaim.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
+	"unique"
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +34,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	opts "sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
 	"sigs.k8s.io/karpenter/pkg/utils/resources"
 )
 
@@ -111,22 +114,22 @@ func NewNodeClaim(
 // CanAdd returns whether the pod can be added to the NodeClaim
 // based on the taints/tolerations, host port compatibility,
 // requirements, resources, reserved capacity reservations, and topology requirements
-func (n *NodeClaim) CanAdd(ctx context.Context, pod *corev1.Pod, podData *PodData, relaxMinValues bool) (updatedRequirements scheduling.Requirements, updatedInstanceTypes []*cloudprovider.InstanceType, offeringsToReserve []*cloudprovider.Offering, err error) {
+func (n *NodeClaim) CanAdd(ctx context.Context, pod *corev1.Pod, podData *PodData, relaxMinValues bool, allocator *dynamicresources.Allocator) (updatedRequirements scheduling.Requirements, updatedInstanceTypes []*cloudprovider.InstanceType, offeringsToReserve []*cloudprovider.Offering, allocationResult *dynamicresources.AllocationResult, err error) {
 	// Check Taints
 	if err := scheduling.Taints(n.Spec.Taints).ToleratesPod(pod); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	// exposed host ports on the node
 	hostPorts := scheduling.GetHostPorts(pod)
 	if err := n.hostPortUsage.Conflicts(pod, hostPorts); err != nil {
-		return nil, nil, nil, fmt.Errorf("checking host port usage, %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("checking host port usage, %w", err)
 	}
 	baseRequirements := scheduling.NewRequirements(n.Requirements.Values()...)
 
 	// Check NodeClaim Affinity Requirements
 	if err := baseRequirements.Compatible(podData.Requirements, scheduling.AllowUndefinedWellKnownLabels); err != nil {
-		return nil, nil, nil, fmt.Errorf("incompatible requirements, %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("incompatible requirements, %w", err)
 	}
 	baseRequirements.Add(podData.Requirements.Values()...)
 
@@ -142,19 +145,21 @@ func (n *NodeClaim) CanAdd(ctx context.Context, pod *corev1.Pod, podData *PodDat
 	// volume topology constraints affect downstream topology checks (e.g., pod anti-affinity).
 	var lastErr error
 	for _, volReqs := range volumeAlternatives {
-		reqs, its, ofs, err := n.tryVolumeAlternative(ctx, pod, podData, baseRequirements, volReqs, relaxMinValues)
+		reqs, its, ofs, result, err := n.tryVolumeAlternative(ctx, pod, podData, baseRequirements, volReqs, relaxMinValues, allocator)
 		if err != nil {
 			lastErr = err
 			continue
 		}
-		return reqs, its, ofs, nil
+		return reqs, its, ofs, result, nil
 	}
-	return nil, nil, nil, lastErr
+	return nil, nil, nil, nil, lastErr
 }
 
 // tryVolumeAlternative attempts to add a pod with a specific set of volume requirements,
 // checking topology, instance types, and offerings compatibility.
-func (n *NodeClaim) tryVolumeAlternative(ctx context.Context, pod *corev1.Pod, podData *PodData, baseRequirements scheduling.Requirements, volReqs scheduling.Requirements, relaxMinValues bool) (scheduling.Requirements, []*cloudprovider.InstanceType, []*cloudprovider.Offering, error) {
+//
+//nolint:gocyclo
+func (n *NodeClaim) tryVolumeAlternative(ctx context.Context, pod *corev1.Pod, podData *PodData, baseRequirements scheduling.Requirements, volReqs scheduling.Requirements, relaxMinValues bool, allocator *dynamicresources.Allocator) (scheduling.Requirements, []*cloudprovider.InstanceType, []*cloudprovider.Offering, *dynamicresources.AllocationResult, error) {
 	nodeClaimRequirements := scheduling.NewRequirements(baseRequirements.Values()...)
 
 	// Add volume requirements to nodeClaimRequirements ONLY (not to pod's affinity).
@@ -162,20 +167,41 @@ func (n *NodeClaim) tryVolumeAlternative(ctx context.Context, pod *corev1.Pod, p
 	// while TSC counting uses pod's original affinity.
 	if volReqs != nil {
 		if err := nodeClaimRequirements.Compatible(volReqs, scheduling.AllowUndefinedWellKnownLabels); err != nil {
-			return nil, nil, nil, fmt.Errorf("incompatible volume requirements, %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("incompatible volume requirements, %w", err)
 		}
 		nodeClaimRequirements.Add(volReqs.Values()...)
 	}
 
+	// Simulate DRA device allocation before instance-type filtering so the topology requirements contributed by the
+	// allocated devices tighten the NodeClaim's requirements and feed the full filtering pipeline.
+	var allocationResult *dynamicresources.AllocationResult
+	if podData.HasResourceClaimRequests && allocator != nil {
+		if podData.ResourceClaimErr != nil {
+			return nil, nil, nil, nil, podData.ResourceClaimErr
+		}
+		result, err := allocator.Allocate(ctx, &draNodeClaim{nc: n}, podData.ResourceClaims)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("allocating dynamic resources, %w", err)
+		}
+		// Merge the allocation's topology requirements into the NodeClaim's requirements (intersection-based narrowing).
+		if err := nodeClaimRequirements.Compatible(result.Requirements, scheduling.AllowUndefinedWellKnownLabels); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("incompatible dynamic resource requirements, %w", err)
+		}
+		nodeClaimRequirements.Add(result.Requirements.Values()...)
+		allocationResult = result
+	}
+
 	// Check Topology Requirements
-	// NOTE: podData.StrictRequirements does NOT include volume requirements,
-	// ensuring TSC counting uses pod's original affinity.
+	// NOTE: podData.StrictRequirements does NOT include volume requirements, ensuring TSC counting uses pod's original
+	// affinity.
+	// NOTE: Topology requirements should come last since they can result in a single domain from a set of compatible
+	// domains. This can result in unnecessary failures from subsequent checks that narrow requirements.
 	topologyRequirements, err := n.topology.AddRequirements(pod, n.Spec.Taints, podData.StrictRequirements, nodeClaimRequirements, scheduling.AllowUndefinedWellKnownLabels)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if err = nodeClaimRequirements.Compatible(topologyRequirements, scheduling.AllowUndefinedWellKnownLabels); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	nodeClaimRequirements.Add(topologyRequirements.Values()...)
 
@@ -192,19 +218,31 @@ func (n *NodeClaim) tryVolumeAlternative(ctx context.Context, pod *corev1.Pod, p
 	if err != nil {
 		// We avoid wrapping this err because calling String() on InstanceTypeFilterError is an expensive operation
 		// due to calls to resources.Merge and stringifying the nodeClaimRequirements
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
+	}
+	// Apply the DRA-specific instance type filter: only instance types whose device allocation succeeded survive.
+	if allocationResult != nil {
+		supported := sets.New(lo.Map(allocationResult.InstanceTypes, func(it dynamicresources.InstanceTypeID, _ int) string {
+			return it.Value()
+		})...)
+		remaining = lo.Filter(remaining, func(it *cloudprovider.InstanceType, _ int) bool {
+			return supported.Has(it.Name)
+		})
+		if len(remaining) == 0 {
+			return nil, nil, nil, nil, fmt.Errorf("no instance type satisfies both scheduling and dynamic resource requirements")
+		}
 	}
 	ofs, err := n.offeringsToReserve(ctx, remaining, nodeClaimRequirements)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return nodeClaimRequirements, remaining, ofs, nil
+	return nodeClaimRequirements, remaining, ofs, allocationResult, nil
 }
 
 // Add updates the NodeClaim to schedule the pod to this NodeClaim, updating
 // the NodeClaim with new requirements, instance types, and offerings to reserve
 // based on the pod scheduling
-func (n *NodeClaim) Add(pod *corev1.Pod, podData *PodData, nodeClaimRequirements scheduling.Requirements, instanceTypes []*cloudprovider.InstanceType, offeringsToReserve []*cloudprovider.Offering) {
+func (n *NodeClaim) Add(ctx context.Context, pod *corev1.Pod, podData *PodData, nodeClaimRequirements scheduling.Requirements, instanceTypes []*cloudprovider.InstanceType, offeringsToReserve []*cloudprovider.Offering, allocationResult *dynamicresources.AllocationResult, allocator *dynamicresources.Allocator) {
 	// Update node
 	n.Pods = append(n.Pods, pod)
 	n.InstanceTypeOptions = instanceTypes
@@ -216,6 +254,25 @@ func (n *NodeClaim) Add(pod *corev1.Pod, podData *PodData, nodeClaimRequirements
 	n.reservationManager.Reserve(n.hostname, offeringsToReserve...)
 	n.releaseReservedOfferings(n.reservedOfferings, offeringsToReserve)
 	n.reservedOfferings = offeringsToReserve
+
+	// Commit the DRA device allocation now that the placement decision is finalized, then release the allocator's
+	// reservations for any instance types that the allocator simulated but were pruned from the NodeClaim's final
+	// candidate set (e.g. by offering/fit filters). This frees those instance types' devices for other NodeClaims.
+	// The Allocation handle is nil when there were no new device allocations to commit (e.g. every claim was already
+	// allocated in-cluster), in which case there is nothing to commit or release.
+	if allocationResult != nil && allocationResult.Allocation != nil {
+		allocationResult.Allocation.Commit(ctx)
+		committed := sets.New(lo.Map(instanceTypes, func(it *cloudprovider.InstanceType, _ int) string { return it.Name })...)
+		var pruned []dynamicresources.InstanceTypeID
+		for _, it := range allocationResult.InstanceTypes {
+			if !committed.Has(it.Value()) {
+				pruned = append(pruned, it)
+			}
+		}
+		if len(pruned) > 0 {
+			allocator.ReleaseInstanceType(ctx, unique.Make(n.hostname), pruned...)
+		}
+	}
 }
 
 // releaseReservedOfferings releases all offerings which are present in the current reserved offerings, but are not
@@ -287,11 +344,19 @@ func (n *NodeClaim) offeringsToReserve(
 }
 
 // FinalizeScheduling is called once all scheduling has completed and allows the node to perform any cleanup
-// necessary before its requirements are used for instance launching
-func (n *NodeClaim) FinalizeScheduling() {
+// necessary before its requirements are used for instance launching. drivers is the set of DRA driver names whose
+// devices were allocated to pods scheduled to this NodeClaim; when non-empty it is recorded as an annotation for the
+// initialization controller to gate on.
+func (n *NodeClaim) FinalizeScheduling(drivers ...string) {
 	// We need nodes to have hostnames for topology purposes, but we don't want to pass that node name on to consumers
 	// of the node as it will be displayed in error messages
 	delete(n.Requirements, corev1.LabelHostname)
+	if len(drivers) != 0 {
+		slices.Sort(drivers)
+		n.Annotations = lo.Assign(n.Annotations, map[string]string{
+			v1.DRADriversAnnotationKey: strings.Join(drivers, ","),
+		})
+	}
 	// If there are any reserved offerings tracked, inject those requirements onto the NodeClaim. This ensures that if
 	// there are multiple reserved offerings for an instance type, we don't attempt to overlaunch into a single offering.
 	if len(n.reservedOfferings) != 0 {

--- a/pkg/controllers/provisioning/scheduling/reservationmanager_test.go
+++ b/pkg/controllers/provisioning/scheduling/reservationmanager_test.go
@@ -69,33 +69,30 @@ var _ = Describe("ReservationManager", func() {
 		}
 		// Create hardcoded instance types with reserved offerings
 		instanceTypes = []*cloudprovider.InstanceType{
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "small-reserved",
-				Resources: corev1.ResourceList{
+			fake.NewInstanceType("small-reserved",
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("2"),
 					corev1.ResourceMemory: resource.MustParse("4Gi"),
 					corev1.ResourcePods:   resource.MustParse("10"),
-				},
-				Offerings: []*cloudprovider.Offering{threeCapacityOffering},
-			}),
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "medium-reserved",
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(*threeCapacityOffering),
+			),
+			fake.NewInstanceType("medium-reserved",
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("4"),
 					corev1.ResourceMemory: resource.MustParse("8Gi"),
 					corev1.ResourcePods:   resource.MustParse("20"),
-				},
-				Offerings: []*cloudprovider.Offering{twoCapacityOffering},
-			}),
-			fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "large-reserved",
-				Resources: corev1.ResourceList{
+				}),
+				fake.WithOfferings(*twoCapacityOffering),
+			),
+			fake.NewInstanceType("large-reserved",
+				fake.WithResources(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("8"),
 					corev1.ResourceMemory: resource.MustParse("16Gi"),
 					corev1.ResourcePods:   resource.MustParse("40"),
-				},
-				Offerings: []*cloudprovider.Offering{oneCapacityOffering},
-			}),
+				}),
+				fake.WithOfferings(*oneCapacityOffering),
+			),
 		}
 
 		// Extract offerings from instance types

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -48,7 +49,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	karpopts "sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
-
+	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
 	"sigs.k8s.io/karpenter/pkg/utils/disruption"
 	"sigs.k8s.io/karpenter/pkg/utils/pod"
 	"sigs.k8s.io/karpenter/pkg/utils/resources"
@@ -134,6 +135,7 @@ func NewScheduler(
 	recorder events.Recorder,
 	clock clock.Clock,
 	volumeReqsByPod map[types.UID][]scheduling.Requirements,
+	allocator *dynamicresources.Allocator,
 	opts ...Options,
 ) *Scheduler {
 	minValuesPolicy := option.Resolve(opts...).minValuesPolicy
@@ -187,6 +189,9 @@ func NewScheduler(
 		preferencePolicy:        option.Resolve(opts...).preferencePolicy,
 		minValuesPolicy:         minValuesPolicy,
 		numConcurrentReconciles: lo.Ternary(option.Resolve(opts...).numConcurrentReconciles > 0, option.Resolve(opts...).numConcurrentReconciles, 1),
+		allocator:               allocator,
+		instanceTypes:           instanceTypes,
+		cachedResourceClaims:    map[types.NamespacedName]*resourcev1.ResourceClaim{},
 	}
 
 	npByName := lo.SliceToMap(nodePools, func(np *v1.NodePool) (string, *v1.NodePool) {
@@ -215,6 +220,12 @@ type PodData struct {
 	StrictRequirements       scheduling.Requirements
 	HasResourceClaimRequests bool
 	VolumeRequirements       []scheduling.Requirements // Volume topology requirement alternatives
+
+	// ResourceClaims are the resolved ResourceClaim objects referenced by the pod, populated for DRA pods when the
+	// allocator is enabled. ResourceClaimErr records a resolution failure (e.g. a claim that hasn't been created yet),
+	// in which case the pod is deferred to a subsequent scheduling loop.
+	ResourceClaims   []*resourcev1.ResourceClaim
+	ResourceClaimErr error
 }
 
 type Scheduler struct {
@@ -239,6 +250,13 @@ type Scheduler struct {
 	minValuesPolicy         karpopts.MinValuesPolicy
 	numConcurrentReconciles int
 	deletingNodeNames       sets.Set[string]
+
+	// allocator simulates DRA device allocation for pods with ResourceClaims. It is nil when DRA support is disabled.
+	allocator *dynamicresources.Allocator
+	// instanceTypes is the per-NodePool instance type set, used to resolve template devices for existing nodes.
+	instanceTypes map[string][]*cloudprovider.InstanceType
+	// cachedResourceClaims memoizes ResourceClaim lookups for the duration of a single scheduling loop.
+	cachedResourceClaims map[types.NamespacedName]*resourcev1.ResourceClaim
 }
 
 // DRAError indicates a pod will not be attempted to be scheduled because it has Dynamic Resource Allocation requirements
@@ -262,9 +280,10 @@ func (e DRAError) Unwrap() error {
 
 // Results contains the results of the scheduling operation
 type Results struct {
-	NewNodeClaims []*NodeClaim
-	ExistingNodes []*ExistingNode
-	PodErrors     map[*corev1.Pod]error
+	NewNodeClaims              []*NodeClaim
+	ExistingNodes              []*ExistingNode
+	PodErrors                  map[*corev1.Pod]error
+	DRAClaimAllocationMetadata map[types.NamespacedName]*dynamicresources.ResourceClaimAllocationMetadata
 }
 
 // Record sends eventing and log messages back for the results that were produced from a scheduling run
@@ -418,6 +437,7 @@ func (r Results) TruncateInstanceTypes(ctx context.Context, maxInstanceTypes int
 	return r
 }
 
+//nolint:gocyclo
 func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, error) {
 	defer metrics.Measure(DurationSeconds, map[string]string{ControllerLabel: injection.GetControllerName(ctx)})()
 	// We loop trying to schedule unschedulable pods as long as we are making progress.  This solves a few
@@ -432,7 +452,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, err
 	QueueDepth.DeletePartialMatch(map[string]string{ControllerLabel: injection.GetControllerName(ctx)})
 	podCountByZone := make(map[string]int)
 	for _, p := range pods {
-		s.updateCachedPodData(p)
+		s.updateCachedPodData(ctx, p)
 		if p.Status.Phase == corev1.PodPending {
 			zone := s.computeEffectiveZoneFromPod(p)
 			podCountByZone[zone]++
@@ -464,7 +484,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, err
 				log.FromContext(ctx).Error(e, "failed updating topology")
 			}
 			// Update the cached podData since the pod was relaxed, and it could have changed its requirement set
-			s.updateCachedPodData(pod)
+			s.updateCachedPodData(ctx, pod)
 			q.Push(pod)
 		} else {
 			delete(podErrors, pod)
@@ -472,7 +492,7 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, err
 	}
 	UnfinishedWorkSeconds.Delete(map[string]string{ControllerLabel: injection.GetControllerName(ctx), schedulingIDLabel: string(s.uuid)})
 	for _, m := range s.newNodeClaims {
-		m.FinalizeScheduling()
+		m.FinalizeScheduling(s.draDriversForNodeClaim(m)...)
 	}
 
 	controllerName := injection.GetControllerName(ctx)
@@ -483,11 +503,20 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*corev1.Pod) (Results, err
 		})
 	}
 
-	return Results{
+	results := Results{
 		NewNodeClaims: s.newNodeClaims,
 		ExistingNodes: s.existingNodes,
 		PodErrors:     podErrors,
-	}, ctx.Err()
+	}
+	if s.allocator != nil {
+		results.DRAClaimAllocationMetadata = lo.MapKeys(
+			s.allocator.ResourceClaimAllocationMetadata(),
+			func(_ *dynamicresources.ResourceClaimAllocationMetadata, k dynamicresources.ResourceClaimID) types.NamespacedName {
+				return k.Value()
+			},
+		)
+	}
+	return results, ctx.Err()
 }
 
 func (s *Scheduler) trySchedule(ctx context.Context, p *corev1.Pod) error {
@@ -519,11 +548,11 @@ func (s *Scheduler) trySchedule(ctx context.Context, p *corev1.Pod) error {
 			log.FromContext(ctx).Error(e, "failed updating topology")
 		}
 		// Update the cached podData since the pod was relaxed, and it could have changed its requirement set
-		s.updateCachedPodData(p)
+		s.updateCachedPodData(ctx, p)
 	}
 }
 
-func (s *Scheduler) updateCachedPodData(p *corev1.Pod) {
+func (s *Scheduler) updateCachedPodData(ctx context.Context, p *corev1.Pod) {
 	var requirements scheduling.Requirements
 	if s.preferencePolicy == PreferencePolicyIgnore {
 		requirements = scheduling.NewStrictPodRequirements(p)
@@ -536,19 +565,30 @@ func (s *Scheduler) updateCachedPodData(p *corev1.Pod) {
 		// preferred node affinity.  Only required node affinities can actually reduce pod domains.
 		strictRequirements = scheduling.NewStrictPodRequirements(p)
 	}
-	s.cachedPodData[p.UID] = &PodData{
+	data := &PodData{
 		Requests:                 resources.RequestsForPods(p),
 		Requirements:             requirements,
 		StrictRequirements:       strictRequirements,
 		HasResourceClaimRequests: pod.HasDRARequirements(p),
 		VolumeRequirements:       s.volumeReqsByPod[p.UID], // Volume requirements
 	}
+	// Resolve the pod's ResourceClaims once, in the sequential path, so the parallel candidate evaluation can reuse them
+	// without per-candidate API lookups. A resolution failure is recorded and surfaced as a scheduling error in add().
+	if data.HasResourceClaimRequests && s.allocator != nil {
+		data.ResourceClaims, data.ResourceClaimErr = s.resolvePodClaims(ctx, p)
+	}
+	s.cachedPodData[p.UID] = data
 }
 
 func (s *Scheduler) add(ctx context.Context, pod *corev1.Pod) error {
 	// Check if pod has DRA requirements - if so, return DRA error when IgnoreDRARequests is enabled
 	if s.cachedPodData[pod.UID].HasResourceClaimRequests && karpopts.FromContext(ctx).IgnoreDRARequests {
 		return NewDRAError(fmt.Errorf("pod has Dynamic Resource Allocation requirements that are not yet supported by Karpenter"))
+	}
+	// If the pod's ResourceClaims couldn't be resolved (e.g. a referenced claim hasn't been created yet), no candidate
+	// can satisfy it. Surface the error directly so the pod is deferred and retried once the claim exists.
+	if err := s.cachedPodData[pod.UID].ResourceClaimErr; err != nil {
+		return err
 	}
 
 	// first try to schedule against an in-flight real node
@@ -578,6 +618,7 @@ func (s *Scheduler) addToExistingNode(ctx context.Context, p *corev1.Pod) error 
 
 	var existingNode *ExistingNode
 	var requirements scheduling.Requirements
+	var allocationResult *dynamicresources.AllocationResult
 
 	// determine the volumes that will be mounted if the pod schedules
 	volumes, err := scheduling.GetVolumes(ctx, s.kubeClient, p)
@@ -590,7 +631,7 @@ func (s *Scheduler) addToExistingNode(ctx context.Context, p *corev1.Pod) error 
 			// Pending pods and pods from deleting nodes are exempt.
 			return true
 		}
-		r, err := s.existingNodes[i].CanAdd(p, s.cachedPodData[p.UID], volumes)
+		r, result, err := s.existingNodes[i].CanAdd(ctx, p, s.cachedPodData[p.UID], volumes, s.allocator)
 		if err == nil {
 			mu.Lock()
 			defer mu.Unlock()
@@ -601,6 +642,7 @@ func (s *Scheduler) addToExistingNode(ctx context.Context, p *corev1.Pod) error 
 			}
 			existingNode = s.existingNodes[i]
 			requirements = r
+			allocationResult = result
 			idx = i
 			return false
 		}
@@ -608,7 +650,7 @@ func (s *Scheduler) addToExistingNode(ctx context.Context, p *corev1.Pod) error 
 	})
 	// If we set the existingNode to something valid, this means that we successfully scheduled to one of these nodes
 	if existingNode != nil {
-		existingNode.Add(p, s.cachedPodData[p.UID], requirements, volumes)
+		existingNode.Add(ctx, p, s.cachedPodData[p.UID], requirements, volumes, allocationResult)
 		return nil
 	}
 	return fmt.Errorf("failed scheduling pod to existing nodes")
@@ -622,8 +664,9 @@ func (s *Scheduler) addToInflightNode(ctx context.Context, pod *corev1.Pod) erro
 	var updatedRequirements scheduling.Requirements
 	var updatedInstanceTypes []*cloudprovider.InstanceType
 	var offeringsToReserve []*cloudprovider.Offering
+	var allocationResult *dynamicresources.AllocationResult
 	parallelizeUntil(s.numConcurrentReconciles, len(s.newNodeClaims), func(i int) bool {
-		r, its, ofr, err := s.newNodeClaims[i].CanAdd(ctx, pod, s.cachedPodData[pod.UID], false)
+		r, its, ofr, result, err := s.newNodeClaims[i].CanAdd(ctx, pod, s.cachedPodData[pod.UID], false, s.allocator)
 		if err == nil {
 			mu.Lock()
 			defer mu.Unlock()
@@ -636,13 +679,14 @@ func (s *Scheduler) addToInflightNode(ctx context.Context, pod *corev1.Pod) erro
 			updatedRequirements = r
 			updatedInstanceTypes = its
 			offeringsToReserve = ofr
+			allocationResult = result
 			idx = i
 			return false
 		}
 		return true
 	})
 	if inflightNodeClaim != nil {
-		inflightNodeClaim.Add(pod, s.cachedPodData[pod.UID], updatedRequirements, updatedInstanceTypes, offeringsToReserve)
+		inflightNodeClaim.Add(ctx, pod, s.cachedPodData[pod.UID], updatedRequirements, updatedInstanceTypes, offeringsToReserve, allocationResult, s.allocator)
 		return nil
 	}
 	return fmt.Errorf("failed scheduling pod to inflight nodes")
@@ -657,6 +701,7 @@ func (s *Scheduler) addToNewNodeClaim(ctx context.Context, pod *corev1.Pod) erro
 	var updatedRequirements scheduling.Requirements
 	var updatedInstanceTypes []*cloudprovider.InstanceType
 	var offeringsToReserve []*cloudprovider.Offering
+	var allocationResult *dynamicresources.AllocationResult
 
 	errs := make([]error, len(s.nodeClaimTemplates))
 	parallelizeUntil(s.numConcurrentReconciles, len(s.nodeClaimTemplates), func(i int) bool {
@@ -682,7 +727,7 @@ func (s *Scheduler) addToNewNodeClaim(ctx context.Context, pod *corev1.Pod) erro
 			}
 		}
 		nodeClaim := NewNodeClaim(s.nodeClaimTemplates[i], s.topology, s.daemonOverhead[s.nodeClaimTemplates[i]], s.daemonHostPortUsage[s.nodeClaimTemplates[i]], its, s.reservationManager, s.reservedOfferingMode)
-		r, its, ofs, err := nodeClaim.CanAdd(ctx, pod, s.cachedPodData[pod.UID], s.minValuesPolicy == karpopts.MinValuesPolicyBestEffort)
+		r, its, ofs, result, err := nodeClaim.CanAdd(ctx, pod, s.cachedPodData[pod.UID], s.minValuesPolicy == karpopts.MinValuesPolicyBestEffort, s.allocator)
 		if err != nil {
 			errs[i] = err
 
@@ -701,6 +746,7 @@ func (s *Scheduler) addToNewNodeClaim(ctx context.Context, pod *corev1.Pod) erro
 				updatedRequirements = nil
 				updatedInstanceTypes = nil
 				offeringsToReserve = nil
+				allocationResult = nil
 				idx = i
 				return false
 			}
@@ -730,12 +776,13 @@ func (s *Scheduler) addToNewNodeClaim(ctx context.Context, pod *corev1.Pod) erro
 		updatedRequirements = r
 		updatedInstanceTypes = its
 		offeringsToReserve = ofs
+		allocationResult = result
 		idx = i
 		return false
 	})
 	if newNodeClaim != nil {
 		// we will launch this nodeClaim and need to track its maximum possible resource usage against our remaining resources
-		newNodeClaim.Add(pod, s.cachedPodData[pod.UID], updatedRequirements, updatedInstanceTypes, offeringsToReserve)
+		newNodeClaim.Add(ctx, pod, s.cachedPodData[pod.UID], updatedRequirements, updatedInstanceTypes, offeringsToReserve, allocationResult, s.allocator)
 		s.newNodeClaims = append(s.newNodeClaims, newNodeClaim)
 		s.remainingResources[newNodeClaim.NodePoolName] = subtractMax(s.remainingResources[newNodeClaim.NodePoolName], newNodeClaim.InstanceTypeOptions)
 		return nil
@@ -749,7 +796,7 @@ func (s *Scheduler) calculateExistingNodeClaims(ctx context.Context, stateNodes 
 		taints := node.Taints()
 		daemons := s.getCompatibleDaemonPods(ctx, node, taints, daemonSetPods)
 		isUnderConsolidateAfter := enforceConsolidateAfter && disruption.IsUnderConsolidateAfter(nodePoolMap[node.Name()], node.NodeClaim, s.clock)
-		s.existingNodes = append(s.existingNodes, NewExistingNode(node, s.topology, taints, resources.RequestsForPods(daemons...), isUnderConsolidateAfter))
+		s.existingNodes = append(s.existingNodes, NewExistingNode(node, s.topology, taints, resources.RequestsForPods(daemons...), s.instanceTypeForNode(node), isUnderConsolidateAfter))
 		s.updateRemainingResources(node)
 	}
 	s.sortExistingNodes()

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -251,6 +251,7 @@ func setupScheduler(ctx context.Context, pods []*corev1.Pod, opts ...scheduling.
 		events.NewRecorder(&record.FakeRecorder{}),
 		clock,
 		nil, // volumeReqsByPod
+		nil, // allocator
 		opts...,
 	), nil
 }

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -50,6 +50,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
@@ -99,7 +100,7 @@ var _ = BeforeSuite(func() {
 	nodeStateController = informer.NewNodeController(env.Client, cluster)
 	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 	podStateController = informer.NewPodController(env.Client, cluster)
-	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock)
+	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock, deviceallocation.NewController(env.Client))
 	podController = provisioning.NewPodController(env.Client, prov, cluster)
 })
 
@@ -1761,57 +1762,48 @@ var _ = Context("Scheduling", func() {
 			// capacity sizes and prices don't correlate here, regardless we should filter and see that all three instance types
 			// are valid before preferring the cheapest one 'large'
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "medium",
-					Resources: corev1.ResourceList{
+				fake.NewInstanceType("medium",
+					fake.WithResources(corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("2"),
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
-					},
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: pscheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
-								corev1.LabelTopologyZone: "test-zone-1a",
-							}),
-							Price: 3.00,
-						},
-					},
-				}),
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "small",
-					Resources: corev1.ResourceList{
+					}),
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: pscheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+							corev1.LabelTopologyZone: "test-zone-1a",
+						}),
+						Price: 3.00,
+					}),
+				),
+				fake.NewInstanceType("small",
+					fake.WithResources(corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
-					},
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: pscheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
-								corev1.LabelTopologyZone: "test-zone-1a",
-							}),
-							Price: 2.00,
-						},
-					},
-				}),
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "large",
-					Resources: corev1.ResourceList{
+					}),
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: pscheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+							corev1.LabelTopologyZone: "test-zone-1a",
+						}),
+						Price: 2.00,
+					}),
+				),
+				fake.NewInstanceType("large",
+					fake.WithResources(corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("4"),
 						corev1.ResourceMemory: resource.MustParse("4Gi"),
-					},
-					Offerings: []*cloudprovider.Offering{
-						{
-							Available: true,
-							Requirements: pscheduling.NewLabelRequirements(map[string]string{
-								v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
-								corev1.LabelTopologyZone: "test-zone-1a",
-							}),
-							Price: 1.00,
-						},
-					},
-				}),
+					}),
+					fake.WithOfferings(cloudprovider.Offering{
+						Available: true,
+						Requirements: pscheduling.NewLabelRequirements(map[string]string{
+							v1.CapacityTypeLabelKey:  v1.CapacityTypeOnDemand,
+							corev1.LabelTopologyZone: "test-zone-1a",
+						}),
+						Price: 1.00,
+					}),
+				),
 			}
 			ExpectApplied(ctx, env.Client, nodePool)
 			pod := test.UnschedulablePod(
@@ -2051,7 +2043,7 @@ var _ = Context("Scheduling", func() {
 						return []string{o.(*corev1.Pod).Spec.NodeName}
 					},
 				).Build()
-				provisioner := provisioning.NewProvisioner(kubeClient, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock)
+				provisioner := provisioning.NewProvisioner(kubeClient, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock, deviceallocation.NewController(kubeClient))
 				controller := informer.NewNodeController(kubeClient, cluster)
 				// We try to provision a node for an initial unschedulable pod that will create nodeClaim and node bindings
 				ExpectApplied(ctx, kubeClient, nodePool)
@@ -2372,14 +2364,13 @@ var _ = Context("Scheduling", func() {
 		// nolint:gosec
 		It("should pack in-flight nodes before launching new nodes", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "medium",
-					Resources: corev1.ResourceList{
+				fake.NewInstanceType("medium",
+					fake.WithResources(corev1.ResourceList{
 						// enough CPU for four pods + a bit of overhead
 						corev1.ResourceCPU:  resource.MustParse("4.25"),
 						corev1.ResourcePods: resource.MustParse("4"),
-					},
-				}),
+					}),
+				),
 			}
 			opts := test.PodOptions{ResourceRequirements: corev1.ResourceRequirements{
 				Limits: map[corev1.ResourceName]resource.Quantity{
@@ -2773,14 +2764,12 @@ var _ = Context("Scheduling", func() {
 	Describe("VolumeUsage", func() {
 		BeforeEach(func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-				fake.NewInstanceType(
-					fake.InstanceTypeOptions{
-						Name: "instance-type",
-						Resources: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU:  resource.MustParse("1024"),
-							corev1.ResourcePods: resource.MustParse("1024"),
-						},
+				fake.NewInstanceType("instance-type",
+					fake.WithResources(map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:  resource.MustParse("1024"),
+						corev1.ResourcePods: resource.MustParse("1024"),
 					}),
+				),
 			}
 			nodePool.Spec.Limits = nil
 		})
@@ -4217,7 +4206,7 @@ var _ = Context("Scheduling", func() {
 					},
 				},
 			}) // Create 1000 pods which should take long enough to schedule that we should be able to read the queueDepth metric with a value
-			s, err := prov.NewScheduler(ctx, pods, nil, scheduling.DisableReservedCapacityFallback)
+			s, err := prov.NewScheduler(ctx, pods, nil, nil, scheduling.DisableReservedCapacityFallback)
 			Expect(err).To(BeNil())
 
 			var wg sync.WaitGroup
@@ -4289,7 +4278,7 @@ var _ = Context("Scheduling", func() {
 					},
 				},
 			}) // Create 1000 pods which should take long enough to schedule that we should be able to read the queueDepth metric with a value
-			s, err := prov.NewScheduler(ctx, pods, nil, scheduling.DisableReservedCapacityFallback)
+			s, err := prov.NewScheduler(ctx, pods, nil, nil, scheduling.DisableReservedCapacityFallback)
 			Expect(err).To(BeNil())
 			_, err = s.Solve(injection.WithControllerName(ctx, "provisioner"), pods)
 			Expect(err).To(BeNil())
@@ -4561,27 +4550,24 @@ var _ = Context("Scheduling", func() {
 		BeforeEach(func() {
 			cloudProvider.Reset()
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "large-instance-type",
-					Resources: map[corev1.ResourceName]resource.Quantity{
+				fake.NewInstanceType("large-instance-type",
+					fake.WithResources(map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:    resource.MustParse("6"),
 						corev1.ResourceMemory: resource.MustParse("6Gi"),
-					},
-				}),
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "medium-instance-type",
-					Resources: map[corev1.ResourceName]resource.Quantity{
+					}),
+				),
+				fake.NewInstanceType("medium-instance-type",
+					fake.WithResources(map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:    resource.MustParse("3"),
 						corev1.ResourceMemory: resource.MustParse("3Gi"),
-					},
-				}),
-				fake.NewInstanceType(fake.InstanceTypeOptions{
-					Name: "small-instance-type",
-					Resources: map[corev1.ResourceName]resource.Quantity{
+					}),
+				),
+				fake.NewInstanceType("small-instance-type",
+					fake.WithResources(map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:    resource.MustParse("2"),
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
-					},
-				}),
+					}),
+				),
 			}
 			reservedInstanceTypes := []*cloudprovider.InstanceType{cloudProvider.InstanceTypes[1], cloudProvider.InstanceTypes[2]}
 			for _, it := range reservedInstanceTypes {
@@ -4620,8 +4606,8 @@ var _ = Context("Scheduling", func() {
 			// can't schedule all three because we don't know what instance type will be selected in the launch flow, so the
 			// single nodeclaim reserves both the small and medium offerings.
 			bindings := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node := lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node := lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).To(HaveKeyWithValue(cloudprovider.ReservationIDLabel, "r-small-instance-type"))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, "small-instance-type"))
@@ -4632,8 +4618,8 @@ var _ = Context("Scheduling", func() {
 
 			// Again, we'll only be able to schedule a single pod
 			bindings = ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node = lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node = lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).To(HaveKeyWithValue(cloudprovider.ReservationIDLabel, "r-medium-instance-type"))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, "medium-instance-type"))
@@ -4645,8 +4631,8 @@ var _ = Context("Scheduling", func() {
 			// Finally, we schedule the final pod. Since both capacity reservations are now exhausted and their offerings are
 			// marked as unavailable, we will fall back to either OD or spot.
 			bindings = ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node = lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node = lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).ToNot(HaveKey(cloudprovider.ReservationIDLabel))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, Not(Equal(v1.CapacityTypeReserved))))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, "small-instance-type"))
@@ -4690,8 +4676,8 @@ var _ = Context("Scheduling", func() {
 			// selected instance type. Karpenter should successfully provision a reserved instance for one pod, but fail
 			// to provision anything for the second since it won't fallback to OD or spot.
 			bindings := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node := lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node := lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).To(HaveKeyWithValue(cloudprovider.ReservationIDLabel, "r-small-instance-type"))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, "small-instance-type"))
@@ -4702,8 +4688,8 @@ var _ = Context("Scheduling", func() {
 				return bindings.Get(p) == nil
 			})
 			bindings = ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node = lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node = lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).ToNot(HaveKey(cloudprovider.ReservationIDLabel))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, Not(Equal(v1.CapacityTypeReserved))))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, "small-instance-type"))
@@ -4717,13 +4703,12 @@ var _ = Context("Scheduling", func() {
 			// instance type. This test should verify that the scheduler treats these offerings as though they are drawing from
 			// two separate pools.
 			//cloudProvider.InstanceTypesForNodePool[nodePool.Name] = append([]*cloudprovider.InstanceType{}, cloudProvider.InstanceTypes...)
-			distinctInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "small-instance-type",
-				Resources: map[corev1.ResourceName]resource.Quantity{
+			distinctInstanceType := fake.NewInstanceType("small-instance-type",
+				fake.WithResources(map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceCPU:    resource.MustParse("2"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
-				},
-			})
+				}),
+			)
 			distinctInstanceType.Offerings = append(distinctInstanceType.Offerings, &cloudprovider.Offering{
 				ReservationCapacity: 1,
 				Available:           true,
@@ -4769,8 +4754,9 @@ var _ = Context("Scheduling", func() {
 
 			// Since each pod can only schedule to one of the NodePools, and each NodePool has a distinct capacity reservation,
 			// we should be able to schedule both pods simultaneously despite them selecting on the same instance pool.
-			bindings := lo.Values(ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...))
-			Expect(len(bindings)).To(Equal(2))
+			result := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+			Expect(len(result.Bindings)).To(Equal(2))
+			bindings := lo.Values(result.Bindings)
 			for _, binding := range bindings {
 				Expect(binding.Node.Labels).To(HaveKey(cloudprovider.ReservationIDLabel))
 				Expect(binding.Node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
@@ -4826,8 +4812,8 @@ var _ = Context("Scheduling", func() {
 			// - Both instances were launched into the new reservation, leaving a single instance available in the original
 			//   reservation.
 			bindings := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(2))
-			for _, binding := range lo.Values(bindings) {
+			Expect(len(bindings.Bindings)).To(Equal(2))
+			for _, binding := range lo.Values(bindings.Bindings) {
 				Expect(binding.Node.Labels).To(HaveKey(cloudprovider.ReservationIDLabel))
 				Expect(binding.Node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
 				Expect(binding.Node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, targetInstanceType.Name))
@@ -4841,8 +4827,8 @@ var _ = Context("Scheduling", func() {
 			// any reserved offering, but due to the pessimistic algorithm, we'll still defer the remaining pod until the next
 			// simulataion.
 			bindings = ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node := lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node := lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).To(HaveKey(cloudprovider.ReservationIDLabel))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, targetInstanceType.Name))
@@ -4854,8 +4840,8 @@ var _ = Context("Scheduling", func() {
 			// Finally, schedule the remaining pod. Since there are no more remaining reservations, we should expect to see the
 			// pod scheduled to non-reserved capacity.
 			bindings = ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node = lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node = lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).ToNot(HaveKey(cloudprovider.ReservationIDLabel))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, Not(Equal(v1.CapacityTypeReserved))))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, targetInstanceType.Name))
@@ -4875,13 +4861,12 @@ var _ = Context("Scheduling", func() {
 			// instance type. This test should verify that the scheduler treats these offerings as though they are drawing from
 			// two separate pools.
 			//cloudProvider.InstanceTypesForNodePool[nodePool.Name] = append([]*cloudprovider.InstanceType{}, cloudProvider.InstanceTypes...)
-			targetInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: "small-instance-type",
-				Resources: map[corev1.ResourceName]resource.Quantity{
+			targetInstanceType := fake.NewInstanceType("small-instance-type",
+				fake.WithResources(map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceCPU:    resource.MustParse("2"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
-				},
-			})
+				}),
+			)
 			targetInstanceType.Offerings = append(targetInstanceType.Offerings, &cloudprovider.Offering{
 				ReservationCapacity: 1,
 				Available:           true,
@@ -4924,8 +4909,8 @@ var _ = Context("Scheduling", func() {
 			// NodeClaim creation for the second pod will fail. It should fail because there is a reserved offering available
 			// in the higher weight NodePool, but a reservation can't be made in this simulation.
 			bindings := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node := lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node := lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).To(HaveKey(cloudprovider.ReservationIDLabel))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, targetInstanceType.Name))
@@ -4937,8 +4922,8 @@ var _ = Context("Scheduling", func() {
 			// After the NodeClaims were launched for the first scheduling simulation, the offering in the higher weight NodePool
 			// should have been marked as unavailable. We will now be able to schedule the second pod to the fallback nodepool.
 			bindings = ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node = lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node = lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).ToNot(HaveKey(cloudprovider.ReservationIDLabel))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, Not(Equal(v1.CapacityTypeReserved))))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, targetInstanceType.Name))
@@ -4955,13 +4940,12 @@ var _ = Context("Scheduling", func() {
 			// Ensure that the offering in the other NodePool uses a different reservation. Otherwise the first pod scheduling
 			// via the first NodePool will result in all capacity for compatible offerings on both NodePools being reserved.
 			// This would produce false negatives.
-			distinctInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
-				Name: targetInstanceTypeName,
-				Resources: map[corev1.ResourceName]resource.Quantity{
+			distinctInstanceType := fake.NewInstanceType(targetInstanceTypeName,
+				fake.WithResources(map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceCPU:    resource.MustParse("2"),
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
-				},
-			})
+				}),
+			)
 			distinctInstanceType.Offerings = append(distinctInstanceType.Offerings, &cloudprovider.Offering{
 				ReservationCapacity: 1,
 				Available:           true,
@@ -5008,8 +4992,8 @@ var _ = Context("Scheduling", func() {
 			// we attempt to create a NodeClaim for the second pod, we should fail with a reserved capacity error and requeue the
 			// pod without relaxing preferences. The end result should be deferring scheduling to the next iteration.
 			bindings := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node := lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node := lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).To(HaveKey(cloudprovider.ReservationIDLabel))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, v1.CapacityTypeReserved))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, targetInstanceTypeName))
@@ -5021,8 +5005,8 @@ var _ = Context("Scheduling", func() {
 			// Retry with the remaining pod. Since the pod still has a preferred affinity for the original NodePool, we expect it
 			// to schedule there even though there is no remaining reserved capacity and there is on the other NodePool.
 			bindings = ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(1))
-			node = lo.Values(bindings)[0].Node
+			Expect(len(bindings.Bindings)).To(Equal(1))
+			node = lo.Values(bindings.Bindings)[0].Node
 			Expect(node.Labels).ToNot(HaveKey(cloudprovider.ReservationIDLabel))
 			Expect(node.Labels).To(HaveKeyWithValue(v1.CapacityTypeLabelKey, Not(Equal(v1.CapacityTypeReserved))))
 			Expect(node.Labels).To(HaveKeyWithValue(corev1.LabelInstanceTypeStable, targetInstanceTypeName))
@@ -5072,9 +5056,9 @@ var _ = Context("Scheduling", func() {
 			})
 
 			bindings := ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			Expect(len(bindings)).To(Equal(2))
-			node := lo.Values(bindings)[0].Node
-			for _, b := range lo.Values(bindings) {
+			Expect(len(bindings.Bindings)).To(Equal(2))
+			node := lo.Values(bindings.Bindings)[0].Node
+			for _, b := range lo.Values(bindings.Bindings) {
 				Expect(b.Node.Name).To(Equal(node.Name))
 			}
 			Expect(node.Labels).To(HaveKeyWithValue(cloudprovider.ReservationIDLabel, "r-small-instance-type"))
@@ -5223,7 +5207,7 @@ var _ = Context("Scheduling", func() {
 				// Create the test pod with specified options
 				pod := test.Pod(podOptions)
 
-				scheduler, err := prov.NewScheduler(ctx, []*corev1.Pod{pod}, nil)
+				scheduler, err := prov.NewScheduler(ctx, []*corev1.Pod{pod}, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 				results, err := scheduler.Solve(ctx, []*corev1.Pod{pod})
 				Expect(err).ToNot(HaveOccurred())
@@ -5386,7 +5370,7 @@ var _ = Context("Scheduling", func() {
 			Expect(err).ToNot(HaveOccurred())
 			scheduler1 := scheduling.NewScheduler(ctx1, env.Client, []*v1.NodePool{nodePool}, cluster, nil, topology1,
 				map[string][]*cloudprovider.InstanceType{nodePool.Name: cloudProvider.InstanceTypes},
-				[]*corev1.Pod{draDaemonPod}, events.NewRecorder(&record.FakeRecorder{}), env.Clock, nil)
+				[]*corev1.Pod{draDaemonPod}, events.NewRecorder(&record.FakeRecorder{}), env.Clock, nil, nil)
 			results1, err := scheduler1.Solve(ctx1, []*corev1.Pod{appPod})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results1.NewNodeClaims).To(HaveLen(1))
@@ -5399,7 +5383,7 @@ var _ = Context("Scheduling", func() {
 			Expect(err).ToNot(HaveOccurred())
 			scheduler2 := scheduling.NewScheduler(ctx2, env.Client, []*v1.NodePool{nodePool}, cluster, nil, topology2,
 				map[string][]*cloudprovider.InstanceType{nodePool.Name: cloudProvider.InstanceTypes},
-				[]*corev1.Pod{draDaemonPod}, events.NewRecorder(&record.FakeRecorder{}), env.Clock, nil)
+				[]*corev1.Pod{draDaemonPod}, events.NewRecorder(&record.FakeRecorder{}), env.Clock, nil, nil)
 			results2, err := scheduler2.Solve(ctx2, []*corev1.Pod{appPod})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results2.NewNodeClaims).To(HaveLen(1))

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -42,6 +42,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
@@ -79,7 +80,7 @@ var _ = BeforeSuite(func() {
 	cloudProvider = fake.NewCloudProvider()
 	cluster = state.NewCluster(env.Clock, env.Client, cloudProvider)
 	nodeController = informer.NewNodeController(env.Client, cluster)
-	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock)
+	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock, deviceallocation.NewController(env.Client))
 	daemonsetController = informer.NewDaemonSetController(env.Client, cluster)
 	instanceTypes, _ := cloudProvider.GetInstanceTypes(ctx, nil)
 	instanceTypeMap = map[string]*cloudprovider.InstanceType{}
@@ -523,7 +524,7 @@ var _ = Describe("Provisioning", func() {
 		Expect(len(nodes.Items)).To(Equal(2))
 
 		// Scheduler should attempt to schedule all the pods to the new node
-		for _, n := range bindings {
+		for _, n := range bindings.Bindings {
 			Expect(n.Node.Name).ToNot(Equal(node.Name))
 		}
 	})
@@ -2773,41 +2774,34 @@ var _ = Describe("Provisioning", func() {
 				It("should not schedule when minValues requirement is not met", func() {
 					// Create only two instance types, which doesn't meet the minValues=3 requirement
 					var instanceTypes []*cloudprovider.InstanceType
-					opts1 := fake.InstanceTypeOptions{
-						Name:             "instance-type-1",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-						Offerings: []*cloudprovider.Offering{
-							{
+					instanceTypes = append(instanceTypes,
+						fake.NewInstanceType("instance-type-1",
+							fake.WithArchitecture(v1.ArchitectureArm64),
+							fake.WithOperatingSystems(string(corev1.Linux)),
+							fake.WithResources(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							}),
+							fake.WithOfferings(cloudprovider.Offering{
 								Available:    true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
 								Price:        0.52,
-							},
-						},
-					}
-
-					opts2 := fake.InstanceTypeOptions{
-						Name:             "instance-type-2",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-						Offerings: []*cloudprovider.Offering{
-							{
+							}),
+						),
+						fake.NewInstanceType("instance-type-2",
+							fake.WithArchitecture(v1.ArchitectureArm64),
+							fake.WithOperatingSystems(string(corev1.Linux)),
+							fake.WithResources(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							}),
+							fake.WithOfferings(cloudprovider.Offering{
 								Available:    true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2-spot"}),
 								Price:        0.52,
-							},
-						},
-					}
-
-					instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1), fake.NewInstanceType(opts2))
+							}),
+						),
+					)
 					cloudProvider.InstanceTypes = instanceTypes
 
 					ExpectApplied(ctx, env.Client, defaultNodePool)
@@ -2831,41 +2825,34 @@ var _ = Describe("Provisioning", func() {
 				It("should schedule even when minValues requirement is not met", func() {
 					// Create only two instance types, which doesn't meet the minValues=3 requirement
 					var instanceTypes []*cloudprovider.InstanceType
-					opts1 := fake.InstanceTypeOptions{
-						Name:             "instance-type-1",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-						Offerings: []*cloudprovider.Offering{
-							{
+					instanceTypes = append(instanceTypes,
+						fake.NewInstanceType("instance-type-1",
+							fake.WithArchitecture(v1.ArchitectureArm64),
+							fake.WithOperatingSystems(string(corev1.Linux)),
+							fake.WithResources(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							}),
+							fake.WithOfferings(cloudprovider.Offering{
 								Available:    true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
 								Price:        0.52,
-							},
-						},
-					}
-
-					opts2 := fake.InstanceTypeOptions{
-						Name:             "instance-type-2",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-						Offerings: []*cloudprovider.Offering{
-							{
+							}),
+						),
+						fake.NewInstanceType("instance-type-2",
+							fake.WithArchitecture(v1.ArchitectureArm64),
+							fake.WithOperatingSystems(string(corev1.Linux)),
+							fake.WithResources(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							}),
+							fake.WithOfferings(cloudprovider.Offering{
 								Available:    true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2-spot"}),
 								Price:        0.52,
-							},
-						},
-					}
-
-					instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1), fake.NewInstanceType(opts2))
+							}),
+						),
+					)
 					cloudProvider.InstanceTypes = instanceTypes
 
 					ExpectApplied(ctx, env.Client, defaultNodePool)
@@ -2899,41 +2886,34 @@ var _ = Describe("Provisioning", func() {
 
 				It("should relax minValues before falling back to other nodepools", func() {
 					var instanceTypes []*cloudprovider.InstanceType
-					opts1 := fake.InstanceTypeOptions{
-						Name:             "instance-type-1",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-						Offerings: []*cloudprovider.Offering{
-							{
+					instanceTypes = append(instanceTypes,
+						fake.NewInstanceType("instance-type-1",
+							fake.WithArchitecture(v1.ArchitectureArm64),
+							fake.WithOperatingSystems(string(corev1.Linux)),
+							fake.WithResources(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							}),
+							fake.WithOfferings(cloudprovider.Offering{
 								Available:    true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
 								Price:        0.52,
-							},
-						},
-					}
-
-					opts2 := fake.InstanceTypeOptions{
-						Name:             "instance-type-2",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-						Offerings: []*cloudprovider.Offering{
-							{
+							}),
+						),
+						fake.NewInstanceType("instance-type-2",
+							fake.WithArchitecture(v1.ArchitectureArm64),
+							fake.WithOperatingSystems(string(corev1.Linux)),
+							fake.WithResources(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							}),
+							fake.WithOfferings(cloudprovider.Offering{
 								Available:    true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2-spot"}),
 								Price:        0.52,
-							},
-						},
-					}
-
-					instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1), fake.NewInstanceType(opts2))
+							}),
+						),
+					)
 					cloudProvider.InstanceTypes = instanceTypes
 
 					ExpectApplied(ctx, env.Client, defaultNodePool)
@@ -2982,41 +2962,34 @@ var _ = Describe("Provisioning", func() {
 
 				It("should choose nodepool with higher weight when relaxing minValues", func() {
 					var instanceTypes []*cloudprovider.InstanceType
-					opts1 := fake.InstanceTypeOptions{
-						Name:             "instance-type-1",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-						Offerings: []*cloudprovider.Offering{
-							{
+					instanceTypes = append(instanceTypes,
+						fake.NewInstanceType("instance-type-1",
+							fake.WithArchitecture(v1.ArchitectureArm64),
+							fake.WithOperatingSystems(string(corev1.Linux)),
+							fake.WithResources(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							}),
+							fake.WithOfferings(cloudprovider.Offering{
 								Available:    true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1-spot"}),
 								Price:        0.52,
-							},
-						},
-					}
-
-					opts2 := fake.InstanceTypeOptions{
-						Name:             "instance-type-2",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("4"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-						Offerings: []*cloudprovider.Offering{
-							{
+							}),
+						),
+						fake.NewInstanceType("instance-type-2",
+							fake.WithArchitecture(v1.ArchitectureArm64),
+							fake.WithOperatingSystems(string(corev1.Linux)),
+							fake.WithResources(corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+							}),
+							fake.WithOfferings(cloudprovider.Offering{
 								Available:    true,
 								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2-spot"}),
 								Price:        0.52,
-							},
-						},
-					}
-
-					instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1), fake.NewInstanceType(opts2))
+							}),
+						),
+					)
 					cloudProvider.InstanceTypes = instanceTypes
 
 					ExpectApplied(ctx, env.Client, defaultNodePool)
@@ -3106,28 +3079,26 @@ var _ = Describe("Provisioning", func() {
 				It("should not schedule when zone minValues requirement is not met", func() {
 					// Create instance types with only two zones, which doesn't meet the minValues=3 requirement
 					var instanceTypes []*cloudprovider.InstanceType
-					opts1 := fake.InstanceTypeOptions{
-						Name:             "instance-type-1",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
+					instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+						fake.WithArchitecture(v1.ArchitectureArm64),
+						fake.WithOperatingSystems(string(corev1.Linux)),
+						fake.WithResources(corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("4"),
 							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-					}
-					opts1.Offerings = []*cloudprovider.Offering{
-						{
-							Available:    true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1"}),
-							Price:        0.52,
-						},
-						{
-							Available:    true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2"}),
-							Price:        0.54,
-						},
-					}
-					instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1))
+						}),
+						fake.WithOfferings(
+							cloudprovider.Offering{
+								Available:    true,
+								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1"}),
+								Price:        0.52,
+							},
+							cloudprovider.Offering{
+								Available:    true,
+								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2"}),
+								Price:        0.54,
+							},
+						),
+					))
 					cloudProvider.InstanceTypes = instanceTypes
 
 					ExpectApplied(ctx, env.Client, nodePool)
@@ -3151,28 +3122,26 @@ var _ = Describe("Provisioning", func() {
 				It("should schedule even when zone minValues requirement is not met", func() {
 					// Create instance types with only two zones, which doesn't meet the minValues=3 requirement
 					var instanceTypes []*cloudprovider.InstanceType
-					opts1 := fake.InstanceTypeOptions{
-						Name:             "instance-type-1",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
+					instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+						fake.WithArchitecture(v1.ArchitectureArm64),
+						fake.WithOperatingSystems(string(corev1.Linux)),
+						fake.WithResources(corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("4"),
 							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-					}
-					opts1.Offerings = []*cloudprovider.Offering{
-						{
-							Available:    true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1"}),
-							Price:        0.52,
-						},
-						{
-							Available:    true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2"}),
-							Price:        0.54,
-						},
-					}
-					instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1))
+						}),
+						fake.WithOfferings(
+							cloudprovider.Offering{
+								Available:    true,
+								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1"}),
+								Price:        0.52,
+							},
+							cloudprovider.Offering{
+								Available:    true,
+								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2"}),
+								Price:        0.54,
+							},
+						),
+					))
 					cloudProvider.InstanceTypes = instanceTypes
 
 					ExpectApplied(ctx, env.Client, nodePool)
@@ -3246,28 +3215,26 @@ var _ = Describe("Provisioning", func() {
 
 				It("should schedule when minValues requirement is not met", func() {
 					var instanceTypes []*cloudprovider.InstanceType
-					opts1 := fake.InstanceTypeOptions{
-						Name:             "instance-type-1",
-						Architecture:     v1.ArchitectureArm64,
-						OperatingSystems: sets.New(string(corev1.Linux)),
-						Resources: corev1.ResourceList{
+					instanceTypes = append(instanceTypes, fake.NewInstanceType("instance-type-1",
+						fake.WithArchitecture(v1.ArchitectureArm64),
+						fake.WithOperatingSystems(string(corev1.Linux)),
+						fake.WithResources(corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("4"),
 							corev1.ResourceMemory: resource.MustParse("4Gi"),
-						},
-					}
-					opts1.Offerings = []*cloudprovider.Offering{
-						{
-							Available:    true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1"}),
-							Price:        0.52,
-						},
-						{
-							Available:    true,
-							Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2"}),
-							Price:        0.54,
-						},
-					}
-					instanceTypes = append(instanceTypes, fake.NewInstanceType(opts1))
+						}),
+						fake.WithOfferings(
+							cloudprovider.Offering{
+								Available:    true,
+								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-1"}),
+								Price:        0.52,
+							},
+							cloudprovider.Offering{
+								Available:    true,
+								Requirements: scheduling.NewLabelRequirements(map[string]string{v1.CapacityTypeLabelKey: v1.CapacityTypeSpot, corev1.LabelTopologyZone: "test-zone-2"}),
+								Price:        0.54,
+							},
+						),
+					))
 					cloudProvider.InstanceTypes = instanceTypes
 
 					ExpectApplied(ctx, env.Client, defaultNodePool)
@@ -3336,25 +3303,19 @@ func ExpectNodeClaimRequests(nodeClaim *v1.NodeClaim, resources corev1.ResourceL
 }
 
 func AddInstanceResources(instanceTypes []*cloudprovider.InstanceType, resources corev1.ResourceList) []*cloudprovider.InstanceType {
-	opts := fake.InstanceTypeOptions{
-		Name:             "example",
-		Architecture:     "arch",
-		Resources:        resources,
-		OperatingSystems: sets.New(string(corev1.Linux)),
-	}
-	price := fake.PriceFromResources(opts.Resources)
-	opts.Offerings = []*cloudprovider.Offering{
-		{
+	price := fake.PriceFromResources(resources)
+	instanceTypes = append(instanceTypes, fake.NewInstanceType("example",
+		fake.WithArchitecture("arch"),
+		fake.WithResources(resources),
+		fake.WithOperatingSystems(string(corev1.Linux)),
+		fake.WithOfferings(cloudprovider.Offering{
 			Available: true,
 			Requirements: scheduling.NewLabelRequirements(map[string]string{
 				v1.CapacityTypeLabelKey:  v1.CapacityTypeSpot,
 				corev1.LabelTopologyZone: "test-zone-1",
 			}),
 			Price: price,
-		},
-	}
-
-	instanceTypes = append(instanceTypes, fake.NewInstanceType(opts))
-
+		}),
+	))
 	return instanceTypes
 }

--- a/pkg/controllers/static/provisioning/controller.go
+++ b/pkg/controllers/static/provisioning/controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
@@ -56,12 +57,12 @@ type Controller struct {
 	cluster       *state.Cluster
 }
 
-func NewController(kubeClient client.Client, cluster *state.Cluster, recorder events.Recorder, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, clock clock.Clock) *Controller {
+func NewController(kubeClient client.Client, cluster *state.Cluster, recorder events.Recorder, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, clock clock.Clock, deviceAllocationController *deviceallocation.Controller) *Controller {
 	return &Controller{
 		kubeClient:    kubeClient,
 		cloudProvider: cloudProvider,
 		cluster:       cluster,
-		provisioner:   provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster, clock),
+		provisioner:   provisioning.NewProvisioner(kubeClient, recorder, cloudProvider, cluster, clock, deviceAllocationController),
 	}
 }
 

--- a/pkg/controllers/static/provisioning/suite_test.go
+++ b/pkg/controllers/static/provisioning/suite_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/apis"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider/fake"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
@@ -84,12 +85,12 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(test.WithCRDs(apis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
-	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock)
+	prov = provisioning.NewProvisioner(env.Client, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster, env.Clock, deviceallocation.NewController(env.Client))
 	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)
 	cluster = state.NewCluster(env.Clock, env.Client, cloudProvider)
 	nodeController = informer.NewNodeController(env.Client, cluster)
 	daemonsetController = informer.NewDaemonSetController(env.Client, cluster)
-	controller = static.NewController(env.Client, cluster, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, prov, env.Clock)
+	controller = static.NewController(env.Client, cluster, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, prov, env.Clock, deviceallocation.NewController(env.Client))
 	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cloudProvider, cluster, clusterCost)
 })
 
@@ -123,7 +124,7 @@ var _ = Describe("Static Provisioning Controller", func() {
 			ExpectApplied(ctx, env.Client, nodePool)
 
 			// Create controller with failing client
-			failingController := static.NewController(&failingClient{Client: env.Client}, cluster, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, prov, env.Clock)
+			failingController := static.NewController(&failingClient{Client: env.Client}, cluster, events.NewRecorder(&record.FakeRecorder{}), cloudProvider, prov, env.Clock, deviceallocation.NewController(env.Client))
 
 			result, err := failingController.Reconcile(ctx, nodePool)
 			Expect(err).To(HaveOccurred())

--- a/pkg/scheduling/dynamicresources/allocator.go
+++ b/pkg/scheduling/dynamicresources/allocator.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/awslabs/operatorpkg/serrors"
 	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,6 +59,11 @@ type Allocator struct {
 	// claimAllocationMetadata contains metadata for in-memory ResourceClaim allocations, including the allocated devices
 	// and the scheduling requirements.
 	claimAllocationMetadata map[ResourceClaimID]*ResourceClaimAllocationMetadata
+	// deletingPodUIDs is the set of pods that are migrating off their current nodes (pods on deleting nodes, disruption
+	// candidates, and individually-deleting pods). A ResourceClaim whose reservedFor is composed entirely of these pods
+	// is treated as unallocated and re-run through the DFS, so its device — already freed from the allocated-device seed
+	// set for the same reason — is re-allocated rather than treated as committed in place.
+	deletingPodUIDs sets.Set[types.UID]
 }
 
 // ResourceClaimAllocationMetadataForClaim returns a copy of the allocator's internal ResourceClaim allocation metadata.
@@ -149,7 +155,11 @@ func NewAllocator(
 	allocatedState AllocatedDeviceState,
 	attributeBindings AttributeBindings,
 	kubeClient client.Client,
+	deletingPodUIDs sets.Set[types.UID],
 ) *Allocator {
+	if deletingPodUIDs == nil {
+		deletingPodUIDs = sets.New[types.UID]()
+	}
 	return &Allocator{
 		allocationTracker:       NewAllocationTracker(allocatedState),
 		attributeBindings:       attributeBindings,
@@ -157,6 +167,7 @@ func NewAllocator(
 		inClusterSlices:         inClusterSlices,
 		poolCache:               make(map[NodeClaimID][]*Pool),
 		claimAllocationMetadata: make(map[ResourceClaimID]*ResourceClaimAllocationMetadata),
+		deletingPodUIDs:         deletingPodUIDs,
 	}
 }
 
@@ -384,12 +395,23 @@ type classificationResult struct {
 // ClassifyClaims evaluates the set of claims for the NodeClaims. It checks allocation status and ensures compatibility.
 // If any of claim is already allocated and incompatible with the NodeClaim, it returns an error. The result is the set
 // of unallocated claims and the cumalative requirements derived from the base NodeClaim and the allocated claims.
+//
+//nolint:gocyclo
 func (a *Allocator) ClassifyClaims(nodeClaim NodeClaim, claims []*resourcev1.ResourceClaim) (classificationResult, error) {
 	result := classificationResult{
 		requirements: copyRequirements(nodeClaim.Requirements()),
 	}
 
 	for _, claim := range claims {
+		// A claim reserved entirely by pods that are migrating off their nodes is re-allocated rather than treated as
+		// committed in place: the device it currently holds has already been freed from the allocated-device seed set
+		// (see gatherAllocatedDevices), so the DFS must re-allocate the claim onto the replacement capacity. A claim
+		// reserved by a mix of deleting and live pods — or by any non-pod consumer — stays committed below, preserving
+		// the live consumers' device and topology.
+		if claim.Status.Allocation != nil && a.claimReservedEntirelyByDeletingPods(claim) {
+			result.unallocatedClaims = append(result.unallocatedClaims, claim)
+			continue
+		}
 		// In-cluster allocated: status.allocation is set.
 		if claim.Status.Allocation != nil {
 			reqs := nodeSelectorsToRequirements(claim.Status.Allocation.NodeSelector)
@@ -427,6 +449,27 @@ func (a *Allocator) ClassifyClaims(nodeClaim NodeClaim, claims []*resourcev1.Res
 		result.unallocatedClaims = append(result.unallocatedClaims, claim)
 	}
 	return result, nil
+}
+
+// claimReservedEntirelyByDeletingPods reports whether a ResourceClaim is reserved by a non-empty set of pod consumers
+// that are all in the allocator's deletingPodUIDs set. Such a claim's pods are all migrating off their nodes, so the
+// claim should be re-allocated rather than treated as committed in place. A claim reserved by a non-pod consumer, by a
+// live pod, or by nothing at all returns false (it stays committed). This mirrors the pod-consumer accounting in the
+// deviceallocation controller and the allConsumersDeleting predicate used to free devices.
+func (a *Allocator) claimReservedEntirelyByDeletingPods(claim *resourcev1.ResourceClaim) bool {
+	if len(claim.Status.ReservedFor) == 0 {
+		return false
+	}
+	for i := range claim.Status.ReservedFor {
+		ref := &claim.Status.ReservedFor[i]
+		if ref.Resource != string(corev1.ResourcePods) || ref.APIGroup != "" {
+			return false
+		}
+		if !a.deletingPodUIDs.Has(ref.UID) {
+			return false
+		}
+	}
+	return true
 }
 
 // allocator is the per-Allocate() child struct that holds mutable state for the current DFS.

--- a/pkg/scheduling/dynamicresources/allocator.go
+++ b/pkg/scheduling/dynamicresources/allocator.go
@@ -309,9 +309,9 @@ func (a *Allocator) Allocate(
 	// Phase 2: Pool gathering with cache, using the tightened effective requirements.
 	var pools []*Pool
 	if cached, ok := a.poolCache[nodeClaim.ID()]; ok {
-		pools = FilterPools(cached, classifyRes.requirements)
+		pools = FilterPools(cached, classifyRes.requirements, nodeClaim.NodeName())
 	} else {
-		pools = GatherPools(a.inClusterSlices, classifyRes.requirements)
+		pools = GatherPools(a.inClusterSlices, classifyRes.requirements, nodeClaim.NodeName())
 	}
 
 	// Build template devices by instance type.
@@ -635,7 +635,7 @@ func (a *allocator) allocate(instanceTypes []InstanceTypeID) (*AllocationResult,
 			allocator:                       a.Allocator,
 			nodeClaimID:                     a.nodeClaim.ID(),
 			deviceIDsByIT:                   deviceIDsByIT,
-			filteredPools:                   FilterPools(initialPools, a.requirements),
+			filteredPools:                   FilterPools(initialPools, a.requirements, a.nodeClaim.NodeName()),
 			claimMetadata:                   claimAllocMetaByRC,
 			counterConsumptionByIT:          counterConsumptionByIT,
 			templateCounterConsumptionByIT:  templateCounterConsumptionByIT,
@@ -825,7 +825,7 @@ func (a *allocator) tryDevice(
 			pools: a.pools,
 		})
 		a.requirements.Add(dw.TopologyRequirements.Values()...)
-		a.pools = FilterPools(a.pools, a.requirements)
+		a.pools = FilterPools(a.pools, a.requirements, a.nodeClaim.NodeName())
 		a.buildPoolIndex()
 		pushedSnapshot = true
 	}

--- a/pkg/scheduling/dynamicresources/allocator_test.go
+++ b/pkg/scheduling/dynamicresources/allocator_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Allocator", func() {
 	Describe("Empty claims", func() {
 		It("should return immediately with no claims", func() {
 			nc := makeNodeClaim("it-1")
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			result, err := alloc.Allocate(ctx, nc, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.InstanceTypes).To(HaveLen(1))
@@ -291,7 +291,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should allocate a single device", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
 
@@ -303,7 +303,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should allocate multiple devices for a single request", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 3))
 
@@ -313,7 +313,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should fail when not enough devices are available", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 5))
 
@@ -322,7 +322,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should handle multiple requests in a single claim", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1",
 				exactRequest("req-1", "gpu", 2),
@@ -335,7 +335,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should fail when multiple requests exceed total devices", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1",
 				exactRequest("req-1", "gpu", 3),
@@ -347,7 +347,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should handle multiple claims", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claims := []*resourcev1.ResourceClaim{
 				makeClaim("c1", exactRequest("req-1", "gpu", 2)),
@@ -362,7 +362,7 @@ var _ = Describe("Allocator", func() {
 		It("should distinguish claims with the same name in different namespaces", func() {
 			// ResourceClaims are namespaced, so two claims sharing a name across namespaces must be
 			// tracked independently rather than colliding on a name-only key.
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claimNS1 := makeClaim("c1", exactRequest("req-1", "gpu", 1))
 			claimNS1.Namespace = "ns-1"
@@ -391,7 +391,7 @@ var _ = Describe("Allocator", func() {
 				deviceID("gpu.example.com", "pool-a", "gpu-1").DeviceID,
 				deviceID("gpu.example.com", "pool-a", "gpu-2").DeviceID,
 			)
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 2))
 
@@ -404,7 +404,7 @@ var _ = Describe("Allocator", func() {
 				deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID,
 				deviceID("gpu.example.com", "pool-a", "gpu-1").DeviceID,
 			)
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 2))
 
@@ -426,7 +426,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should allocate a node-name-pinned device for the existing node it belongs to", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			nc.nodeName = "node-a"
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
@@ -438,7 +438,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should not allocate a node-name-pinned device for a different existing node", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			nc.nodeName = "node-b"
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
@@ -448,7 +448,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should not allocate a node-name-pinned device for an in-flight NodeClaim", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1") // no node name — in-flight
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
 
@@ -491,7 +491,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should only allocate devices matching the selector", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "h100", 2))
 
@@ -501,7 +501,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should fail when not enough devices match the selector", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "h100", 3))
 
@@ -510,7 +510,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should filter with request-level selectors", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1",
 				exactRequestWithSelector("req-1", "gpu", 1, `device.attributes["gpu.example.com"].model == "A100"`),
@@ -548,7 +548,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should satisfy MatchAttribute constraints", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaimWithConstraints("c1",
 				[]resourcev1.DeviceConstraint{
@@ -563,7 +563,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should backtrack to satisfy constraints", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			// Request 3 devices that must share a NUMA node — only 2 per NUMA, so this should fail.
 			claim := makeClaimWithConstraints("c1",
@@ -580,7 +580,7 @@ var _ = Describe("Allocator", func() {
 		It("should satisfy constraints with backtracking across requests", func() {
 			// 2 devices on node-0, 2 on node-1. Two requests of 2 each.
 			// Each constraint is scoped to one request, so req-1 gets node-0 pair and req-2 gets node-1 pair (or vice versa).
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaimWithConstraints("c1",
 				[]resourcev1.DeviceConstraint{
@@ -614,7 +614,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should allocate from templates when in-cluster devices are insufficient", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-b", "tgpu-0", "tgpu-1"),
 			)
@@ -627,7 +627,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should prefer in-cluster devices over templates", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-b", "tgpu-0", "tgpu-1"),
 			)
@@ -657,7 +657,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 2))
 
@@ -683,7 +683,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			// 3 devices × 40Gi > 80Gi budget — only 2 can be allocated.
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 3))
@@ -712,7 +712,7 @@ var _ = Describe("Allocator", func() {
 			allocated := sets.New[cloudprovider.DeviceID](
 				deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID,
 			)
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			// gpu-1 needs 40Gi, and only 40Gi remains (80Gi - 40Gi from gpu-0). Should succeed.
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
@@ -739,7 +739,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Pod 1: allocate 2 devices (uses 80Gi of budget).
 			nc1 := makeNodeClaimWithID("nc-1", "it-1")
@@ -791,7 +791,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// 2 devices: 80Gi memory (ok) + 100 flops (ok).
@@ -835,7 +835,7 @@ var _ = Describe("Allocator", func() {
 			allocated := sets.New[cloudprovider.DeviceID](
 				deviceID("gpu.example.com", "pool-a", "gpu-offnode").DeviceID,
 			)
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client, nil)
 
 			// NodeClaim is in us-west-2a — the s-offnode slice (eu-west-1a) becomes non-targeting.
 			nc := &fakeNodeClaim{
@@ -874,7 +874,7 @@ var _ = Describe("Allocator", func() {
 						),
 					),
 				}
-				alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+				alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 				return makeNodeClaim("it-1")
 			}),
 			Entry("in-cluster device references non-existent counter name", func() dynamicresources.NodeClaim {
@@ -892,11 +892,11 @@ var _ = Describe("Allocator", func() {
 						),
 					),
 				}
-				alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+				alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 				return makeNodeClaim("it-1")
 			}),
 			Entry("template device references non-existent counter set", func() dynamicresources.NodeClaim {
-				alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+				alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 				return makeNodeClaimWithTemplates(makeTemplateWithCounters("gpu.example.com", "pool-a",
 					[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
 						"memory": resource.MustParse("80Gi"),
@@ -905,7 +905,7 @@ var _ = Describe("Allocator", func() {
 				))
 			}),
 			Entry("template device references non-existent counter name", func() dynamicresources.NodeClaim {
-				alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+				alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 				return makeNodeClaimWithTemplates(makeTemplateWithCounters("gpu.example.com", "pool-a",
 					[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
 						"memory": resource.MustParse("80Gi"),
@@ -933,7 +933,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
 
@@ -956,7 +956,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
 
@@ -984,7 +984,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A allocates 2 devices (80Gi) and commits.
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -1025,7 +1025,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A with 2 ITs: DFS order means IT-A gets gpu-0 (40Gi), IT-B also gets gpu-0 (40Gi).
 			// Pessimistic max = 40Gi (same device, same consumption for both ITs).
@@ -1091,7 +1091,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// 2 devices: 80Gi memory (ok), 4 compute-units (ok) — both budgets exactly met.
@@ -1132,7 +1132,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			// Request 2 devices with MatchAttribute on numa — DFS must backtrack past gpu-2 (node-1)
 			// and allocate gpu-0 + gpu-1 (both node-0), with counters correctly restored.
@@ -1164,7 +1164,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// All mode: 2 devices × 40Gi = 80Gi > 60Gi budget. Should fail.
@@ -1189,7 +1189,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// All-mode: total counter consumption = 30+30 = 60Gi ≤ 80Gi budget. Should succeed.
@@ -1216,7 +1216,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A with 2 ITs: both ITs allocate 2 devices (80Gi each). Pessimistic max = 80Gi.
 			// Remaining: 120 - 80 = 40Gi.
@@ -1267,7 +1267,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A with 2 ITs: it-a requests 1 device (40Gi), it-b requests 2 devices (80Gi).
 			// Pessimistic max = max(40, 80) = 80Gi. Remaining: 120 - 80 = 40Gi.
@@ -1354,7 +1354,7 @@ var _ = Describe("Allocator", func() {
 				},
 			}
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Commit 1: claim needs 1 gpu + 1 nic. it-1 gets both (gpu-0=60Gi + nic-0).
 			// it-2 fails (no nic device). Only it-1 survives.
@@ -1409,7 +1409,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Pod 1 on NC-A: allocates 1 device (40Gi). Committed: 40Gi.
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -1449,7 +1449,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A with 2 ITs both allocate 2 devices (80Gi each). Pessimistic max = 80Gi.
 			// Remaining: 120 - 80 = 40Gi.
@@ -1494,7 +1494,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A with 2 ITs. Both allocate via DFS order — same devices, same consumption.
 			// Commit 1 device for pod 1, then 2 devices for pod 2.
@@ -1543,7 +1543,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			itID := unique.Make("it-1")
 			nc := &fakeNodeClaim{
@@ -1615,7 +1615,7 @@ var _ = Describe("Allocator", func() {
 				},
 			)
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-1: allocate 1 gpu (pool-a: 50Gi) + 1 nic (pool-b: 50G).
 			nc1 := makeNodeClaimWithID("nc-1", "it-a")
@@ -1676,7 +1676,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC with two ITs. Claim: 1 gpu with tier=high (only gpu-0 matches — consumes both counter sets).
 			// IT-A picks gpu-0 (consumes memory-budget:40Gi + compute-budget:50).
@@ -1748,7 +1748,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC with it-a and it-b. Claim: 1 device with tier=full.
 			// Both ITs pick dev-full → consume memory:50Gi + bandwidth:100G.
@@ -1816,7 +1816,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A (it-a, it-b): 1 device kind=mem → both ITs pick dev-mem-0 (memory:40Gi).
 			ncA := makeNodeClaimWithID("nc-a", "it-a", "it-b")
@@ -1880,7 +1880,7 @@ var _ = Describe("Allocator", func() {
 					},
 				},
 			)
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
 
@@ -1936,7 +1936,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
 
@@ -2001,7 +2001,7 @@ var _ = Describe("Allocator", func() {
 					},
 				},
 			)
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A allocates from both pools, commits, then releases.
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -2026,7 +2026,7 @@ var _ = Describe("Allocator", func() {
 
 	Describe("SharedCounters — templates", func() {
 		It("should allocate template devices when counter budget is sufficient", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplateWithCounters("gpu.example.com", "pool-a",
 					[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
@@ -2045,7 +2045,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should reject template allocation when counter budget is exhausted", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplateWithCounters("gpu.example.com", "pool-a",
 					[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
@@ -2064,7 +2064,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should evaluate template counters independently per instance type", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			// it-large has 160Gi budget (fits 4 devices), it-small has 80Gi budget (fits only 2).
 			nc := makeMultiITNodeClaim(map[string][]*cloudprovider.ResourceSliceTemplate{
 				"it-large": {makeTemplateWithCounters("gpu.example.com", "pool-a",
@@ -2096,7 +2096,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should not share template counter budgets across pods", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			tmpl := makeTemplateWithCounters("gpu.example.com", "pool-a",
 				[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
 					"memory": resource.MustParse("80Gi"),
@@ -2122,7 +2122,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should accumulate template counter consumption across multiple pods on the same NC/IT", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			// 4 devices × 40Gi each, but only 80Gi budget — max 2 devices allocatable per NC/IT.
 			tmpl := makeTemplateWithCounters("gpu.example.com", "pool-a",
 				[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
@@ -2148,7 +2148,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should allow template counter allocation on a different NC after exhausting budget on the first", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			tmpl := makeTemplateWithCounters("gpu.example.com", "pool-a",
 				[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
 					"memory": resource.MustParse("80Gi"),
@@ -2174,7 +2174,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should release template counter budget when instance type is pruned", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			tmpl := makeTemplateWithCounters("gpu.example.com", "pool-a",
 				[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
 					"memory": resource.MustParse("80Gi"),
@@ -2203,7 +2203,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should track template counter deductions within a single claim with multiple requests", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplateWithCounters("gpu.example.com", "pool-a",
 					[]resourcev1.CounterSet{counterSet("gpu-slices", map[string]resource.Quantity{
@@ -2225,7 +2225,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should handle multiple template slices for the same pool key", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			// Two template slices for same driver/pool, each contributing part of the counter budget.
 			nc := makeNodeClaimWithTemplates(
 				makeTemplateWithCounters("gpu.example.com", "pool-a",
@@ -2251,7 +2251,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should handle multiple counter sets per template slice", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplateWithCounters("gpu.example.com", "pool-a",
 					[]resourcev1.CounterSet{
@@ -2285,7 +2285,7 @@ var _ = Describe("Allocator", func() {
 			// Template device has ConsumesCounters but the template slice has NO SharedCounters.
 			// buildTemplateCounters() returns nil → templateRemainingCounters is nil →
 			// checkCounters receives nil remainingCounterSets → returns false.
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Template with devices that consume counters but NO SharedCounters declared.
 			nc := makeNodeClaimWithTemplates(&cloudprovider.ResourceSliceTemplate{
@@ -2310,7 +2310,7 @@ var _ = Describe("Allocator", func() {
 			// templateRemainingCounters), pool-B's device has ConsumesCounters but pool-B's
 			// slice has no SharedCounters. When pool-B device is evaluated,
 			// templateRemainingCounters is non-nil (from pool-A) but has no entry for pool-B.
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			itID := unique.Make("it-1")
 			nc := &fakeNodeClaim{
@@ -2356,7 +2356,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// it-large has 2 template devices, it-small has 0.
 			nc := makeMultiITNodeClaim(map[string][]*cloudprovider.ResourceSliceTemplate{
@@ -2379,7 +2379,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			nc := makeMultiITNodeClaim(map[string][]*cloudprovider.ResourceSliceTemplate{
 				"it-a": {makeTemplate("gpu.example.com", "pool-b", "tgpu-0")},
@@ -2394,7 +2394,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should fail when no instance type can satisfy", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeMultiITNodeClaim(map[string][]*cloudprovider.ResourceSliceTemplate{
 				"it-a": {makeTemplate("gpu.example.com", "pool-b", "tgpu-0")},
 				"it-b": {makeTemplate("gpu.example.com", "pool-c", "tgpu-0")},
@@ -2410,7 +2410,7 @@ var _ = Describe("Allocator", func() {
 		It("should not leak constraint state between instance type iterations", func() {
 			// IT-A has template devices with numa=node-0, IT-B has template devices with numa=node-1.
 			// Both should independently satisfy a MatchAttribute constraint on numa.
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeMultiITNodeClaim(map[string][]*cloudprovider.ResourceSliceTemplate{
 				"it-a": {makeTemplateWithAttrs("gpu.example.com", "pool-a",
 					deviceWithAttrs("tgpu-0", map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
@@ -2464,7 +2464,7 @@ var _ = Describe("Allocator", func() {
 				},
 			})
 
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, bindings, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, bindings, env.Client, nil)
 			nc := makeMultiITNodeClaim(map[string][]*cloudprovider.ResourceSliceTemplate{
 				"it-a": {makeTemplate("gpu.example.com", "pool-a", "tgpu-0", "tgpu-1")},
 				"it-b": {makeTemplateWithAttrs("gpu.example.com", "pool-b",
@@ -2493,7 +2493,7 @@ var _ = Describe("Allocator", func() {
 			// IT-A has devices with conflicting NUMA values (can't satisfy constraint).
 			// IT-B has devices with matching NUMA values (can satisfy).
 			// Verifies that failed DFS backtracking leaves clean state.
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeMultiITNodeClaim(map[string][]*cloudprovider.ResourceSliceTemplate{
 				"it-a": {makeTemplateWithAttrs("gpu.example.com", "pool-a",
 					deviceWithAttrs("tgpu-0", map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
@@ -2534,7 +2534,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1", "gpu-2")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// First allocation: 2 devices.
@@ -2554,7 +2554,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
@@ -2576,7 +2576,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1", "gpu-2")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", allRequest("req-1", "gpu"))
 
@@ -2590,7 +2590,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-b", "tgpu-0", "tgpu-1"),
 			)
@@ -2604,7 +2604,7 @@ var _ = Describe("Allocator", func() {
 		It("should include different template device counts per instance type", func() {
 			// it-large has 3 template devices, it-small has 1.
 			// All-mode should succeed for both, but they allocate different total counts.
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeMultiITNodeClaim(map[string][]*cloudprovider.ResourceSliceTemplate{
 				"it-large": {makeTemplate("gpu.example.com", "pool-b", "tgpu-0", "tgpu-1", "tgpu-2")},
 				"it-small": {makeTemplate("gpu.example.com", "pool-c", "tgpu-0")},
@@ -2624,7 +2624,7 @@ var _ = Describe("Allocator", func() {
 			allocated := sets.New[cloudprovider.DeviceID](
 				deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID,
 			)
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: allocated}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", allRequest("req-1", "gpu"))
 
@@ -2669,7 +2669,7 @@ var _ = Describe("Allocator", func() {
 				},
 			)
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1",
 				allRequest("all-compute", "compute"),
@@ -2695,7 +2695,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaimWithConstraints("c1",
 				[]resourcev1.DeviceConstraint{
@@ -2721,7 +2721,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should block devices allocated by a different NodeClaim", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A allocates 2 devices and commits.
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -2744,7 +2744,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should allow the same device on the same NodeClaim for a different instance type", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A with IT-A allocates 2 devices.
 			ncA := makeNodeClaimWithID("nc-a", "it-a")
@@ -2763,7 +2763,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should block the same device on the same NodeClaim and same instance type from a prior pod", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Pod 1 allocates 2 devices for NC-A/IT-A and commits.
 			ncA := makeNodeClaimWithID("nc-a", "it-a")
@@ -2784,7 +2784,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should handle multi-IT NodeClaim device contention across NodeClaims", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A has two ITs and allocates 2 devices per IT.
 			ncA := &fakeNodeClaim{
@@ -2819,7 +2819,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should free devices for other NodeClaims after releasing the only instance type", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A allocates and commits.
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -2844,7 +2844,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should free devices only when the last instance type referencing them is released", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A with two ITs allocates and commits.
 			ncA := &fakeNodeClaim{
@@ -2877,7 +2877,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should be a no-op when releasing an instance type that was never committed", func() {
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Release a non-existent NC/IT — should not panic.
 			alloc.ReleaseInstanceType(ctx, unique.Make("nc-nonexistent"), unique.Make("it-nonexistent"))
@@ -2906,7 +2906,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -2950,7 +2950,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -2984,7 +2984,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -3010,7 +3010,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -3034,7 +3034,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// Allocate but don't commit.
@@ -3055,7 +3055,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
 			claim1 := makeClaim("c1", exactRequest("req-1", "gpu", 2))
@@ -3074,7 +3074,7 @@ var _ = Describe("Allocator", func() {
 
 	Describe("Template device tracking after commit", func() {
 		It("should block template devices for the same NC/IT after commit", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-b", "tgpu-0", "tgpu-1"),
 			)
@@ -3092,7 +3092,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should allow template devices for a different IT on the same NC after commit", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// NC-A with IT-A has 2 template devices.
 			ncAITA := makeNodeClaimWithTemplatesAndID("nc-a", "it-a",
@@ -3133,7 +3133,7 @@ var _ = Describe("Allocator", func() {
 				),
 			}
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplateWithAttrs("gpu.example.com", "pool-b",
 					deviceWithAttrs("tgpu-0", map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
@@ -3176,7 +3176,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaimWithConstraints("c1",
 				[]resourcev1.DeviceConstraint{
@@ -3213,7 +3213,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaimWithConstraints("c1",
 				[]resourcev1.DeviceConstraint{
@@ -3249,7 +3249,7 @@ var _ = Describe("Allocator", func() {
 				},
 			})
 
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, bindings, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, bindings, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-b", "tgpu-0", "tgpu-1", "tgpu-2"),
 			)
@@ -3286,7 +3286,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1", "gpu-2")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// Two claims competing: claim 1 wants 2, claim 2 wants 2. Only 3 available.
@@ -3303,7 +3303,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1", "gpu-2", "gpu-3")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			claims := []*resourcev1.ResourceClaim{
@@ -3337,7 +3337,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			claims := []*resourcev1.ResourceClaim{
@@ -3369,7 +3369,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s2", "gpu.example.com", "pool-b", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 2))
 
@@ -3385,7 +3385,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s2", "gpu.example.com", "pool-b", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("dev-0")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 2))
 
@@ -3428,7 +3428,7 @@ var _ = Describe("Allocator", func() {
 				},
 			)
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// Class requires H100, request requires memory > 60. Only gpu-0 matches both.
@@ -3454,7 +3454,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-b", "tgpu-0", "tgpu-1"),
 			)
@@ -3466,7 +3466,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should fail with zero instance types", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:             unique.Make("test-nc"),
 				nodePoolID:     unique.Make("test-np"),
@@ -3507,7 +3507,7 @@ var _ = Describe("Allocator", func() {
 			}
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// All-mode: should fail because the pool is invalid (duplicate names).
@@ -3547,7 +3547,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-dup").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// ExactCount: pool is invalid, devices are flushed → no devices available.
@@ -3559,7 +3559,7 @@ var _ = Describe("Allocator", func() {
 
 	Describe("In-cluster allocated claim handling", func() {
 		It("should pass through claims with no nodeSelector", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeAllocatedClaim("c1", nil)
 
@@ -3569,7 +3569,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should propagate topology requirements from the allocation nodeSelector", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -3595,7 +3595,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should fail when the allocation nodeSelector is incompatible with NodeClaim requirements", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -3634,7 +3634,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -3666,7 +3666,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			claims := []*resourcev1.ResourceClaim{
@@ -3679,7 +3679,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should return early when all claims are already allocated", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			claims := []*resourcev1.ResourceClaim{
@@ -3692,7 +3692,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should fail when two in-cluster allocated claims have incompatible zones", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -3726,7 +3726,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should succeed when two in-cluster allocated claims have compatible zones", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -3769,7 +3769,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			ncA := &fakeNodeClaim{
 				id:         unique.Make("nc-a"),
@@ -3808,6 +3808,80 @@ var _ = Describe("Allocator", func() {
 			_, err = alloc.Allocate(ctx, ncB, []*resourcev1.ResourceClaim{inClusterClaim, inMemoryClaim})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("incompatible"))
+		})
+	})
+
+	Describe("Deleting-pod claim reclassification", func() {
+		// reservedClaim builds a claim already allocated to a real in-cluster device and reserved by the given consumers.
+		// When every consumer is a deleting pod, the allocator should re-allocate it (re-run DFS) rather than treat it as
+		// committed in place — so it must re-acquire a device from the available pool.
+		reservedClaim := func(consumers ...resourcev1.ResourceClaimConsumerReference) *resourcev1.ResourceClaim {
+			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
+			claim.Status = resourcev1.ResourceClaimStatus{
+				Allocation: &resourcev1.AllocationResult{
+					Devices: resourcev1.DeviceAllocationResult{
+						Results: []resourcev1.DeviceRequestAllocationResult{{
+							Request: "req-1", Driver: "gpu.example.com", Pool: "pool-a", Device: "gpu-0",
+						}},
+					},
+				},
+				ReservedFor: consumers,
+			}
+			return claim
+		}
+		podRef := func(uid string) resourcev1.ResourceClaimConsumerReference {
+			return resourcev1.ResourceClaimConsumerReference{Resource: "pods", Name: "pod-" + uid, UID: types.UID(uid)}
+		}
+		// inClusterSlices provides a single published cluster-wide GPU so a reclassified claim has a device to re-acquire.
+		inClusterSlices := func() []dynamicresources.ResourceSlice {
+			return []dynamicresources.ResourceSlice{
+				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0"), withGeneration(1, 1)),
+			}
+		}
+
+		It("re-allocates a claim reserved entirely by deleting pods", func() {
+			alloc = dynamicresources.NewAllocator(inClusterSlices(), dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, sets.New[types.UID]("deleting"))
+			nc := makeNodeClaim("it-1")
+			claim := reservedClaim(podRef("deleting"))
+
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			// The claim was reclassified as unallocated and re-ran the DFS, producing a fresh allocation.
+			Expect(result.Allocation).ToNot(BeNil())
+		})
+
+		It("treats a claim reserved by a mix of deleting and live pods as committed", func() {
+			// No in-cluster slices: if the claim were reclassified as unallocated, the DFS would fail to find a device.
+			// Because a live consumer remains, the claim stays committed in place and allocation succeeds with no DFS.
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, sets.New[types.UID]("deleting"))
+			nc := makeNodeClaim("it-1")
+			claim := reservedClaim(podRef("deleting"), podRef("live"))
+
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.InstanceTypes).To(HaveLen(1))
+		})
+
+		It("treats a claim reserved by a live pod as committed", func() {
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, sets.New[types.UID]("deleting"))
+			nc := makeNodeClaim("it-1")
+			claim := reservedClaim(podRef("live"))
+
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.InstanceTypes).To(HaveLen(1))
+		})
+
+		It("treats a claim reserved by a non-pod consumer as committed", func() {
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, sets.New[types.UID]("deleting"))
+			nc := makeNodeClaim("it-1")
+			// A non-pod consumer (e.g. a different resource kind) is never treated as deleting, so the claim stays committed.
+			claim := reservedClaim(resourcev1.ResourceClaimConsumerReference{Resource: "widgets", APIGroup: "example.com", Name: "w", UID: types.UID("deleting")})
+
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.InstanceTypes).To(HaveLen(1))
 		})
 	})
 
@@ -3880,7 +3954,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices2, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices2, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			nc2 := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
@@ -3918,7 +3992,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
@@ -3951,7 +4025,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
@@ -3993,7 +4067,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
@@ -4030,7 +4104,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
@@ -4063,7 +4137,7 @@ var _ = Describe("Allocator", func() {
 
 	Describe("Validation errors through Allocate()", func() {
 		It("should return error when DeviceClass does not exist", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-a", "tgpu-0"),
 			)
@@ -4076,7 +4150,7 @@ var _ = Describe("Allocator", func() {
 
 		It("should return error for unsupported selector type", func() {
 			// Use a request-level non-CEL selector (API server validates class selectors).
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-a", "tgpu-0"),
 			)
@@ -4107,7 +4181,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should return error for FirstAvailable request", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-a", "tgpu-0"),
 			)
@@ -4129,7 +4203,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should return error for unsupported constraint type", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplate("gpu.example.com", "pool-a", "tgpu-0"),
 			)
@@ -4197,7 +4271,7 @@ var _ = Describe("Allocator", func() {
 				),
 			}
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, bindings, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, bindings, env.Client, nil)
 			// Template device WITHOUT the numa attribute (will use binding fallback path).
 			nc := makeNodeClaimWithTemplates(
 				makeTemplateWithAttrs("gpu.example.com", "pool-tmpl",
@@ -4241,7 +4315,7 @@ var _ = Describe("Allocator", func() {
 				},
 			})
 
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, bindings, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, bindings, env.Client, nil)
 			nc := makeNodeClaimWithTemplates(
 				makeTemplateWithAttrs("gpu.example.com", "pool-tmpl",
 					deviceWithAttrs("tgpu-0", map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{}),
@@ -4277,7 +4351,7 @@ var _ = Describe("Allocator", func() {
 				),
 			}
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			claim := makeClaimWithConstraints("c1",
@@ -4336,7 +4410,7 @@ var _ = Describe("Allocator", func() {
 				},
 			)
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// All "compute" devices + 1 "extra" device, all sharing NUMA constraint.
@@ -4393,7 +4467,7 @@ var _ = Describe("Allocator", func() {
 				},
 			)
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			claim := makeClaimWithConstraints("c1",
@@ -4420,7 +4494,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
@@ -4459,7 +4533,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
 
@@ -4508,7 +4582,7 @@ var _ = Describe("Allocator", func() {
 					},
 				},
 			)
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
@@ -4555,7 +4629,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s2", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 2), withAPIDevices("gpu-0", "gpu-2")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", allRequest("req-1", "gpu"))
 
@@ -4570,7 +4644,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 2), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", allRequest("req-1", "gpu"))
 
@@ -4600,7 +4674,7 @@ var _ = Describe("Allocator", func() {
 					),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			claim := makeClaimWithConstraints("c1",
@@ -4632,7 +4706,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s3", "gpu.example.com", "pool-c", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-2")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", allRequest("req-1", "gpu"))
 
@@ -4657,7 +4731,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := &fakeNodeClaim{
 				id:         unique.Make("test-nc"),
 				nodePoolID: unique.Make("test-np"),
@@ -4680,7 +4754,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 
 			// Pod 1: allocate and commit.
@@ -4702,7 +4776,7 @@ var _ = Describe("Allocator", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 					withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Pod 1 on NC-A.
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -4719,7 +4793,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should fail when a template-allocated claim is referenced from a different NodeClaim", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Pod 1 on NC-A with template devices.
 			ncA := makeNodeClaimWithTemplatesAndID("nc-a", "it-1",
@@ -4740,7 +4814,7 @@ var _ = Describe("Allocator", func() {
 		})
 
 		It("should succeed when a template-allocated claim is referenced from the same NodeClaim", func() {
-			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			// Pod 1 on NC-A with template devices.
 			ncA := makeNodeClaimWithTemplatesAndID("nc-a", "it-1",
@@ -4777,7 +4851,7 @@ var _ = Describe("Allocator", func() {
 				},
 			)
 
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			ncA := makeNodeClaimWithTemplatesAndID("nc-a", "it-1",
 				makeTemplate("fpga.example.com", "pool-fpga", "fpga-0"),
 			)
@@ -4819,7 +4893,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			ncA := &fakeNodeClaim{
 				id:         unique.Make("nc-a"),
 				nodePoolID: unique.Make("test-np"),
@@ -4859,7 +4933,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			ncA := &fakeNodeClaim{
 				id:         unique.Make("nc-a"),
 				nodePoolID: unique.Make("test-np"),
@@ -4933,7 +5007,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 			ncA := &fakeNodeClaim{
 				id:         unique.Make("nc-a"),
 				nodePoolID: unique.Make("test-np"),
@@ -5003,7 +5077,7 @@ var _ = Describe("Allocator", func() {
 					withGeneration(1, 1),
 				),
 			}
-			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client, nil)
 
 			broadReqs := scheduling.NewRequirements(
 				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a", "us-west-2b"),
@@ -5063,7 +5137,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -5107,7 +5181,7 @@ var _ = Describe("Allocator", func() {
 						"gpu.example.com/vram": resource.MustParse("70Gi"),
 					},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -5137,7 +5211,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1",
@@ -5187,7 +5261,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1",
@@ -5232,7 +5306,7 @@ var _ = Describe("Allocator", func() {
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					deviceID("gpu.example.com", "pool-a", "gpu-1").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1",
@@ -5261,7 +5335,7 @@ var _ = Describe("Allocator", func() {
 			}
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
@@ -5297,7 +5371,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// First allocation: 16Gi
 			nc1 := makeNodeClaimWithID("nc-1", "it-1")
@@ -5355,7 +5429,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
@@ -5397,7 +5471,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaimWithID("nc-a", "it-a", "it-b")
 			claim := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -5449,7 +5523,7 @@ var _ = Describe("Allocator", func() {
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					deviceID("gpu.example.com", "pool-a", "gpu-1").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -5485,7 +5559,7 @@ var _ = Describe("Allocator", func() {
 			// NOT seeding ConsumedCapacity — fresh device discovered during allocation.
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// NC-A allocates 16Gi
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -5526,7 +5600,7 @@ var _ = Describe("Allocator", func() {
 		It("should handle template multi-alloc devices with capacity constraints", func() {
 			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaimWithTemplatesAndID("nc-a", "it-1",
 				&cloudprovider.ResourceSliceTemplate{
@@ -5594,7 +5668,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				// Allocate 10 times (10 * 8Gi = 80Gi = full capacity)
 				for i := range 10 {
@@ -5646,7 +5720,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				nc := makeNodeClaim("it-1")
 				claim := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -5691,7 +5765,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				nc := makeNodeClaim("it-1")
 				claim := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -5730,7 +5804,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				nc := makeNodeClaim("it-1")
 				// Request 5Gi — should round up to 8Gi (Min=4Gi + 1*Step=4Gi)
@@ -5793,7 +5867,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				nc := makeNodeClaim("it-1")
 				// Two requests each asking 5Gi (rounds to 8Gi each) — 16Gi total, exact fit
@@ -5856,7 +5930,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				nc := makeNodeClaim("it-1")
 				// Request 55Gi: rounds up to 56Gi (Min=4Gi + 13*Step=52Gi → 56Gi), which exceeds Max=50Gi.
@@ -5897,7 +5971,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				nc := makeNodeClaim("it-1")
 				// Request 48Gi: already step-aligned (Min=4Gi + 11*4Gi = 48Gi) and equals Max.
@@ -5938,7 +6012,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				nc := makeNodeClaim("it-1")
 				// Without Step, roundUpRange returns the request as-is (since it >= Min).
@@ -5979,7 +6053,7 @@ var _ = Describe("Allocator", func() {
 					ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 						deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					},
-				}, nil, env.Client)
+				}, nil, env.Client, nil)
 
 				nc := makeNodeClaim("it-1")
 				// 30Gi: above Min=4Gi, below Max=50Gi, no Step → returned as-is.
@@ -6032,7 +6106,7 @@ var _ = Describe("Allocator", func() {
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 					deviceID("gpu.example.com", "pool-a", "gpu-1").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// Request bandwidth — gpu-0 doesn't have it, gpu-1 does.
@@ -6071,7 +6145,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// Request 16Gi vram (fits in 80Gi) and 12Gi bandwidth (exceeds 10Gi).
@@ -6104,7 +6178,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// Request 16Gi vram and 5Gi bandwidth — both fit.
@@ -6149,7 +6223,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// Two requests: first uses 16Gi vram + 4Gi bw, second uses 16Gi vram + 4Gi bw.
@@ -6198,7 +6272,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -6230,7 +6304,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			claim1 := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -6285,7 +6359,7 @@ var _ = Describe("Allocator", func() {
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
 				ConsumedCapacity: consumedCapacity,
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// NC-A allocates the multi-alloc device.
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -6330,7 +6404,7 @@ var _ = Describe("Allocator", func() {
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New(deviceID("gpu.example.com", "pool-a", "gpu-exclusive").DeviceID),
 				ConsumedCapacity: consumedCapacity,
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// Request 1 device: gpu-exclusive is blocked, gpu-shared has no remaining capacity.
@@ -6359,7 +6433,7 @@ var _ = Describe("Allocator", func() {
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
 				ConsumedCapacity: consumedCapacity,
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// NC-A with 2 ITs both allocate gpu-0.
 			ncA := makeNodeClaimWithID("nc-a", "it-a", "it-b")
@@ -6397,7 +6471,7 @@ var _ = Describe("Allocator", func() {
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
 				ConsumedCapacity: consumedCapacity,
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// NC-A with 2 ITs.
 			ncA := makeNodeClaimWithID("nc-a", "it-a", "it-b")
@@ -6424,7 +6498,7 @@ var _ = Describe("Allocator", func() {
 			// Template devices with AllowMultipleAllocations are tracked per-(NC, IT).
 			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaimWithTemplatesAndID("nc-a", "it-1",
 				&cloudprovider.ResourceSliceTemplate{
@@ -6458,7 +6532,7 @@ var _ = Describe("Allocator", func() {
 		It("should release template capacity when IT is released", func() {
 			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaimWithTemplatesAndID("nc-a", "it-1",
 				&cloudprovider.ResourceSliceTemplate{
@@ -6520,7 +6594,7 @@ var _ = Describe("Allocator", func() {
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
 				ConsumedCapacity: consumedCapacity,
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// Multiple pods commit against the same multi-alloc device.
 			for i := range 5 {
@@ -6555,7 +6629,7 @@ var _ = Describe("Allocator", func() {
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
 				ConsumedCapacity: consumedCapacity,
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// NC-A commits.
 			ncA := makeNodeClaimWithID("nc-a", "it-1")
@@ -6608,7 +6682,7 @@ var _ = Describe("Allocator", func() {
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
 				ConsumedCapacity: consumedCapacity,
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// NC-A with 2 ITs. Both get gpu-0 (count=1). Then second pod: both also get gpu-1.
 			ncA := makeNodeClaimWithID("nc-a", "it-a", "it-b")
@@ -6635,7 +6709,7 @@ var _ = Describe("Allocator", func() {
 		It("should track template consumed capacity per-IT with concrete quantities", func() {
 			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaimWithTemplatesAndID("nc-a", "it-1",
 				&cloudprovider.ResourceSliceTemplate{
@@ -6696,7 +6770,7 @@ var _ = Describe("Allocator", func() {
 		It("should independently track template capacity across different ITs in same NodeClaim", func() {
 			alloc = dynamicresources.NewAllocator(nil, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			template := &cloudprovider.ResourceSliceTemplate{
 				Driver: unique.Make("gpu.example.com"),
@@ -6784,7 +6858,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// NC-A allocates 40Gi (full capacity) with 2 ITs.
 			ncA := makeNodeClaimWithID("nc-a", "it-a", "it-b")
@@ -6837,7 +6911,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// NC-A with it-a: allocate 60Gi
 			ncA := makeNodeClaimWithID("nc-a", "it-a", "it-b")
@@ -6910,7 +6984,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "gpu-0").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			// Pod 1 on NC-A with it-a and it-b: allocates 30Gi.
 			ncA := makeNodeClaimWithID("nc-a", "it-a", "it-b")
@@ -6970,7 +7044,7 @@ var _ = Describe("Allocator", func() {
 						"gpu.example.com/vram": resource.MustParse("30Gi"),
 					},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc1 := makeNodeClaimWithID("nc-1", "it-1")
 			claim1 := makeClaim("c1", exactRequestWithCapacity("req-1", "gpu", 1, map[resourcev1.QualifiedName]resource.Quantity{
@@ -7053,7 +7127,7 @@ var _ = Describe("Allocator", func() {
 						"gpu.example.com/vram": resource.MustParse("10Gi"),
 					},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// Request 2 devices: mig-0 still has capacity (10Gi/20Gi used) and mig-1 is fresh.
@@ -7118,7 +7192,7 @@ var _ = Describe("Allocator", func() {
 			}
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// Each device consumes 20 SMs. Budget is 40. So at most 2 devices can be allocated.
@@ -7171,7 +7245,7 @@ var _ = Describe("Allocator", func() {
 			}
 			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{
 				ExclusiveDevices: sets.New[cloudprovider.DeviceID](),
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 			nc := makeNodeClaim("it-1")
 			// Request count=2. DFS first tries mem-device (slot 1) → exhausts memory-budget.
 			// For slot 2, poolCountersExhausted fires (memory-budget drained) → skips all.
@@ -7231,7 +7305,7 @@ var _ = Describe("Allocator", func() {
 				ConsumedCapacity: map[cloudprovider.DeviceID]map[resourcev1.QualifiedName]resource.Quantity{
 					deviceID("gpu.example.com", "pool-a", "device-a").DeviceID: {},
 				},
-			}, nil, env.Client)
+			}, nil, env.Client, nil)
 
 			nc := makeNodeClaim("it-1")
 			// Request 2 slots with capacity. DFS: slot 1 → device-a (multi-alloc, capacity OK,

--- a/pkg/scheduling/dynamicresources/allocator_test.go
+++ b/pkg/scheduling/dynamicresources/allocator_test.go
@@ -39,6 +39,7 @@ import (
 // fakeNodeClaim implements the NodeClaim interface for testing.
 type fakeNodeClaim struct {
 	id             dynamicresources.NodeClaimID
+	nodeName       string
 	nodePoolID     dynamicresources.NodePoolID
 	requirements   scheduling.Requirements
 	instanceTypes  []dynamicresources.InstanceTypeID
@@ -46,6 +47,7 @@ type fakeNodeClaim struct {
 }
 
 func (f *fakeNodeClaim) ID() dynamicresources.NodeClaimID                 { return f.id }
+func (f *fakeNodeClaim) NodeName() string                                 { return f.nodeName }
 func (f *fakeNodeClaim) NodePoolID() dynamicresources.NodePoolID          { return f.nodePoolID }
 func (f *fakeNodeClaim) Requirements() scheduling.Requirements            { return f.requirements }
 func (f *fakeNodeClaim) InstanceTypes() []dynamicresources.InstanceTypeID { return f.instanceTypes }
@@ -409,6 +411,49 @@ var _ = Describe("Allocator", func() {
 			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeNil())
+		})
+	})
+
+	Describe("Node-name-pinned in-cluster devices", func() {
+		var inClusterSlices []dynamicresources.ResourceSlice
+
+		BeforeEach(func() {
+			// A published slice pinned to node-a via spec.nodeName (the common kubelet/DRA-driver form).
+			inClusterSlices = []dynamicresources.ResourceSlice{
+				makeAPISlice("s1", "gpu.example.com", "pool-a", withNodeName("node-a"),
+					withGeneration(1, 1), withAPIDevices("gpu-0")),
+			}
+		})
+
+		It("should allocate a node-name-pinned device for the existing node it belongs to", func() {
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			nc := makeNodeClaim("it-1")
+			nc.nodeName = "node-a"
+			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
+
+			result, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result.Allocation).ToNot(BeNil())
+		})
+
+		It("should not allocate a node-name-pinned device for a different existing node", func() {
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			nc := makeNodeClaim("it-1")
+			nc.nodeName = "node-b"
+			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
+
+			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not allocate a node-name-pinned device for an in-flight NodeClaim", func() {
+			alloc = dynamicresources.NewAllocator(inClusterSlices, dynamicresources.AllocatedDeviceState{ExclusiveDevices: sets.New[cloudprovider.DeviceID]()}, nil, env.Client)
+			nc := makeNodeClaim("it-1") // no node name — in-flight
+			claim := makeClaim("c1", exactRequest("req-1", "gpu", 1))
+
+			_, err := alloc.Allocate(ctx, nc, []*resourcev1.ResourceClaim{claim})
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/pkg/scheduling/dynamicresources/pool.go
+++ b/pkg/scheduling/dynamicresources/pool.go
@@ -81,14 +81,18 @@ type Pool struct {
 //
 // inClusterSlices are pre-filtered ResourceSlices from the API server (deleting nodes
 // already excluded by the caller).
+//
+// nodeName is the name of the concrete node backing the NodeClaim being evaluated, or "" for in-flight/new
+// NodeClaims. Slices pinned to a node via spec.nodeName contribute devices only when nodeName matches.
 func GatherPools(
 	inClusterSlices []ResourceSlice,
 	requirements scheduling.Requirements,
+	nodeName string,
 ) []*Pool {
 	builders := map[PoolKey]*poolBuilder{}
 
 	for _, s := range inClusterSlices {
-		matched := sliceMatchesRequirements(s, requirements)
+		matched := sliceMatchesRequirements(s, requirements, nodeName)
 		key := PoolKey{Driver: s.Driver(), Pool: s.Pool().Name}
 		b, ok := builders[key]
 		if !ok {
@@ -112,10 +116,10 @@ func GatherPools(
 // matching slices after filtering are dropped entirely. This is used for incremental cache
 // narrowing — the cached superset is re-filtered against tightened requirements without
 // rebuilding from scratch.
-func FilterPools(pools []*Pool, requirements scheduling.Requirements) []*Pool {
+func FilterPools(pools []*Pool, requirements scheduling.Requirements, nodeName string) []*Pool {
 	var filtered []*Pool
 	for _, pool := range pools {
-		if p := filterPool(pool, requirements); p != nil {
+		if p := filterPool(pool, requirements, nodeName); p != nil {
 			filtered = append(filtered, p)
 		}
 	}
@@ -125,7 +129,7 @@ func FilterPools(pools []*Pool, requirements scheduling.Requirements) []*Pool {
 // filterPool returns a copy of the pool containing only slices (and their devices) that match
 // the requirements. Devices with ConsumesCounters on non-matching slices are moved to
 // NonTargetingDevices. Returns nil if no slices match and no NonTargetingDevices exist.
-func filterPool(pool *Pool, requirements scheduling.Requirements) *Pool {
+func filterPool(pool *Pool, requirements scheduling.Requirements, nodeName string) *Pool {
 	p := &Pool{
 		Key:                 pool.Key,
 		Incomplete:          pool.Incomplete,
@@ -134,7 +138,7 @@ func filterPool(pool *Pool, requirements scheduling.Requirements) *Pool {
 		NonTargetingDevices: pool.NonTargetingDevices,
 	}
 	for _, s := range pool.Slices {
-		if !sliceMatchesRequirements(s, requirements) {
+		if !sliceMatchesRequirements(s, requirements, nodeName) {
 			// If the slice no longer matches but has device(s) that consume counters,
 			// we move the device over to NonTargetingDevices
 			for _, d := range s.Devices() {
@@ -161,10 +165,19 @@ func filterPool(pool *Pool, requirements scheduling.Requirements) *Pool {
 	return p
 }
 
-// sliceMatchesRequirements checks whether a ResourceSlice's node affinity is either compatible with
-// the NodeClaim's requirements or when it declares SharedCounters (as they are pool-level budgets)
-// Only in-cluster (non-potential) slices are supported; potential slices indicate a programming error.
-func sliceMatchesRequirements(s ResourceSlice, requirements scheduling.Requirements) bool {
+// sliceMatchesRequirements checks whether a ResourceSlice's node affinity makes its devices accessible to the
+// NodeClaim being evaluated, or whether it declares SharedCounters (which are pool-level budgets accessible
+// everywhere). Only in-cluster (non-potential) slices are supported; potential slices indicate a programming error.
+// nodeName is the name of the concrete node backing the NodeClaim, or "" for in-flight/new NodeClaims that don't yet
+// have a node.
+//
+// A slice is accessible to the NodeClaim when:
+//   - it is AllNodes (accessible everywhere), or
+//   - it declares SharedCounters (pool-level budgets, accessible everywhere), or
+//   - it pins itself to a node via spec.nodeName and that name equals the NodeClaim's node (so it only ever matches an
+//     existing node, never an in-flight one), or
+//   - it uses a label NodeSelector compatible with the NodeClaim's requirements.
+func sliceMatchesRequirements(s ResourceSlice, requirements scheduling.Requirements, nodeName string) bool {
 	if s.Potential() {
 		panic("potential slices must not be passed to pool gathering or filtering")
 	}
@@ -173,6 +186,9 @@ func sliceMatchesRequirements(s ResourceSlice, requirements scheduling.Requireme
 	}
 	if s.SharedCounters() != nil {
 		return true
+	}
+	if sliceNodeName := s.NodeName(); sliceNodeName != "" {
+		return nodeName != "" && sliceNodeName == nodeName
 	}
 	if ns := s.NodeSelector(); ns != nil {
 		return nodeSelectorsMatch(ns, requirements)

--- a/pkg/scheduling/dynamicresources/pool_test.go
+++ b/pkg/scheduling/dynamicresources/pool_test.go
@@ -70,6 +70,13 @@ func withRawNodeSelector(ns *corev1.NodeSelector) func(*resourcev1.ResourceSlice
 	}
 }
 
+//nolint:unparam
+func withNodeName(nodeName string) func(*resourcev1.ResourceSlice) {
+	return func(s *resourcev1.ResourceSlice) {
+		s.Spec.NodeName = &nodeName
+	}
+}
+
 func withAPIDevices(names ...string) func(*resourcev1.ResourceSlice) {
 	return func(s *resourcev1.ResourceSlice) {
 		for _, name := range names {
@@ -172,7 +179,7 @@ var _ = Describe("Pool Gathering", func() {
 			slices := []dynamicresources.ResourceSlice{
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0", "gpu-1")),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(1))
 			Expect(pools[0].Key.Driver).To(Equal(unique.Make("gpu.example.com")))
 			Expect(pools[0].Key.Pool).To(Equal(unique.Make("pool-a")))
@@ -186,7 +193,7 @@ var _ = Describe("Pool Gathering", func() {
 					withAPIDevices("gpu-0"),
 				),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(1))
 		})
 
@@ -197,7 +204,7 @@ var _ = Describe("Pool Gathering", func() {
 					withAPIDevices("gpu-0"),
 				),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(BeEmpty())
 		})
 
@@ -205,12 +212,48 @@ var _ = Describe("Pool Gathering", func() {
 			slices := []dynamicresources.ResourceSlice{
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAPIDevices("gpu-0")),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(BeEmpty())
 		})
 
+		Context("node-name-pinned slices", func() {
+			It("should include a NodeName slice when evaluating the existing node it is pinned to", func() {
+				slices := []dynamicresources.ResourceSlice{
+					makeAPISlice("s1", "gpu.example.com", "pool-a", withNodeName("node-a"), withAPIDevices("gpu-0")),
+				}
+				pools := dynamicresources.GatherPools(slices, reqs, "node-a")
+				Expect(pools).To(HaveLen(1))
+				Expect(pools[0].Devices).To(HaveLen(1))
+			})
+
+			It("should exclude a NodeName slice when evaluating a different node", func() {
+				slices := []dynamicresources.ResourceSlice{
+					makeAPISlice("s1", "gpu.example.com", "pool-a", withNodeName("node-a"), withAPIDevices("gpu-0")),
+				}
+				pools := dynamicresources.GatherPools(slices, reqs, "node-b")
+				Expect(pools).To(BeEmpty())
+			})
+
+			It("should exclude a NodeName slice when evaluating an in-flight NodeClaim (no node name)", func() {
+				slices := []dynamicresources.ResourceSlice{
+					makeAPISlice("s1", "gpu.example.com", "pool-a", withNodeName("node-a"), withAPIDevices("gpu-0")),
+				}
+				pools := dynamicresources.GatherPools(slices, reqs, "")
+				Expect(pools).To(BeEmpty())
+			})
+
+			It("should not apply a node name to AllNodes slices", func() {
+				slices := []dynamicresources.ResourceSlice{
+					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
+				}
+				// AllNodes slices are accessible regardless of the candidate node name, including in-flight NodeClaims.
+				Expect(dynamicresources.GatherPools(slices, reqs, "")).To(HaveLen(1))
+				Expect(dynamicresources.GatherPools(slices, reqs, "node-a")).To(HaveLen(1))
+			})
+		})
+
 		It("should return an empty list when no slices are provided", func() {
-			pools := dynamicresources.GatherPools(nil, reqs)
+			pools := dynamicresources.GatherPools(nil, reqs, "")
 			Expect(pools).To(BeEmpty())
 		})
 
@@ -232,7 +275,7 @@ var _ = Describe("Pool Gathering", func() {
 					withAPIDevices("gpu-0"),
 				),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(1))
 		})
 
@@ -253,7 +296,7 @@ var _ = Describe("Pool Gathering", func() {
 					withAPIDevices("gpu-0"),
 				),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(BeEmpty())
 		})
 
@@ -262,7 +305,7 @@ var _ = Describe("Pool Gathering", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
 				makeAPISlice("s2", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-1")),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(1))
 			Expect(pools[0].Devices).To(HaveLen(2))
 			Expect(pools[0].Slices).To(HaveLen(2))
@@ -273,7 +316,7 @@ var _ = Describe("Pool Gathering", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
 				makeAPISlice("s2", "gpu.example.com", "pool-b", withAllNodes(), withAPIDevices("gpu-1")),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(2))
 		})
 
@@ -282,7 +325,7 @@ var _ = Describe("Pool Gathering", func() {
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
 				makeAPISlice("s2", "nic.example.com", "pool-a", withAllNodes(), withAPIDevices("nic-0")),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(2))
 		})
 
@@ -292,7 +335,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
 					makeAPISlice("s2", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")), // duplicate
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeTrue())
 			})
@@ -302,7 +345,7 @@ var _ = Describe("Pool Gathering", func() {
 					makePotentialSlice("gpu.example.com", "pool-a"),
 				}
 				Expect(func() {
-					dynamicresources.GatherPools(slices, reqs)
+					dynamicresources.GatherPools(slices, reqs, "")
 				}).To(PanicWith("potential slices must not be passed to pool gathering or filtering"))
 			})
 
@@ -310,7 +353,7 @@ var _ = Describe("Pool Gathering", func() {
 				slices := []dynamicresources.ResourceSlice{
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0", "gpu-0")),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeTrue())
 			})
@@ -320,14 +363,14 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
 					makeAPISlice("s2", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-1")),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeFalse())
 			})
 
 			DescribeTable("should mark pool invalid when counter set names are duplicated",
 				func(slices []dynamicresources.ResourceSlice) {
-					pools := dynamicresources.GatherPools(slices, reqs)
+					pools := dynamicresources.GatherPools(slices, reqs, "")
 					Expect(pools).To(HaveLen(1))
 					Expect(pools[0].Invalid).To(BeTrue())
 				},
@@ -372,7 +415,7 @@ var _ = Describe("Pool Gathering", func() {
 
 			DescribeTable("should mark pool invalid when counter references are invalid",
 				func(slices []dynamicresources.ResourceSlice) {
-					pools := dynamicresources.GatherPools(slices, reqs)
+					pools := dynamicresources.GatherPools(slices, reqs, "")
 					Expect(pools).To(HaveLen(1))
 					Expect(pools[0].Invalid).To(BeTrue())
 				},
@@ -516,7 +559,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeFalse())
 			})
@@ -527,7 +570,7 @@ var _ = Describe("Pool Gathering", func() {
 				slices := []dynamicresources.ResourceSlice{
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices[0].ID.Driver).To(Equal(unique.Make("gpu.example.com")))
 				Expect(pools[0].Devices[0].ID.Pool).To(Equal(unique.Make("pool-a")))
@@ -538,7 +581,7 @@ var _ = Describe("Pool Gathering", func() {
 				slices := []dynamicresources.ResourceSlice{
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0", "gpu-1", "gpu-2")),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(3))
 				for i, name := range []string{"gpu-0", "gpu-1", "gpu-2"} {
@@ -554,7 +597,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s2", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-1"), withGeneration(1, 2)),
 					makeAPISlice("s3", "nic.example.com", "pool-b", withAllNodes(), withAPIDevices("nic-0"), withGeneration(1, 1)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(2))
 
 				// Build a map by pool key for order-independent assertions.
@@ -590,7 +633,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s-old", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-old"), withGeneration(1, 1)),
 					makeAPISlice("s-new", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-new"), withGeneration(2, 1)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(1))
 				Expect(pools[0].Devices[0].ID.Device).To(Equal(unique.Make("gpu-new")))
@@ -602,7 +645,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s-old-b", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-1"), withGeneration(1, 2)),
 					makeAPISlice("s-new", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-new"), withGeneration(2, 1)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(1))
 				Expect(pools[0].Devices[0].ID.Device).To(Equal(unique.Make("gpu-new")))
@@ -615,7 +658,7 @@ var _ = Describe("Pool Gathering", func() {
 					// Gen 2: incomplete (1 of 2)
 					makeAPISlice("s-new", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-new"), withGeneration(2, 2)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeTrue())
 				// Should only contain gen 2 devices
@@ -631,7 +674,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s-new-a", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-dup"), withGeneration(2, 2)),
 					makeAPISlice("s-new-b", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-dup"), withGeneration(2, 2)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeTrue())
 				Expect(pools[0].Devices).To(BeEmpty())
@@ -644,7 +687,7 @@ var _ = Describe("Pool Gathering", func() {
 					// Gen 2: complete (1 of 1)
 					makeAPISlice("s-new", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-new"), withGeneration(2, 1)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeFalse())
 				Expect(pools[0].Invalid).To(BeFalse())
@@ -660,7 +703,7 @@ var _ = Describe("Pool Gathering", func() {
 					// Gen 2: valid and complete
 					makeAPISlice("s-new", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-new"), withGeneration(2, 1)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeFalse())
 				Expect(pools[0].Invalid).To(BeFalse())
@@ -673,7 +716,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0"), withGeneration(1, 2)),
 					makeAPISlice("s2", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-1"), withGeneration(1, 2)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(2))
 			})
@@ -685,7 +728,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0"), withGeneration(1, 2)),
 					// Only 1 slice but ResourceSliceCount=2
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeTrue())
 			})
@@ -695,7 +738,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0"), withGeneration(1, 2)),
 					makeAPISlice("s2", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-1"), withGeneration(1, 2)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeFalse())
 			})
@@ -705,7 +748,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0"), withGeneration(1, 1)),
 					makeAPISlice("s2", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-1"), withGeneration(1, 1)),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeTrue())
 			})
@@ -714,7 +757,7 @@ var _ = Describe("Pool Gathering", func() {
 				slices := []dynamicresources.ResourceSlice{
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeTrue())
 			})
@@ -734,7 +777,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeFalse())
 				// Only the matching slice's devices should be visible.
@@ -758,7 +801,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(2, 1),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				// Gen 2 supersedes gen 1. Gen 2 has no matching slices, so pool is nil.
 				Expect(pools).To(BeEmpty())
 			})
@@ -782,7 +825,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 3),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeFalse())
 				Expect(pools[0].Devices).To(HaveLen(2))
@@ -809,7 +852,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].CounterSets).To(HaveKey("memory-budget"))
 				Expect(pools[0].CounterSets["memory-budget"]).To(HaveKey("memory"))
@@ -834,7 +877,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Slices).To(HaveLen(1))
 				Expect(pools[0].CounterSets).To(HaveKey("budget"))
@@ -860,7 +903,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 3),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeFalse())
 			})
@@ -874,7 +917,7 @@ var _ = Describe("Pool Gathering", func() {
 					),
 					// counter-set slice is missing (only 1 of 2 slices present)
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeTrue())
 			})
@@ -898,7 +941,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].CounterSets).To(HaveLen(2))
 				Expect(pools[0].CounterSets).To(HaveKey("memory-budget"))
@@ -925,7 +968,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 3),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeFalse())
 				Expect(pools[0].CounterSets).To(HaveLen(2))
@@ -951,7 +994,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeFalse())
 				Expect(pools[0].CounterSets).To(HaveKey("budget"))
@@ -973,7 +1016,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(1))
 				Expect(pools[0].Devices[0].ID.Device).To(Equal(unique.Make("gpu-0")))
@@ -997,7 +1040,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, narrowReqs)
+				pools := dynamicresources.GatherPools(slices, narrowReqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].CounterSets).To(HaveKey("budget"))
 			})
@@ -1016,7 +1059,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].CounterSets).To(HaveKey("budget"))
 				Expect(pools[0].Devices).To(HaveLen(2))
@@ -1059,7 +1102,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeFalse())
 				Expect(pools[0].Devices).To(HaveLen(1))
@@ -1080,7 +1123,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(BeEmpty())
 			})
 
@@ -1111,7 +1154,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 3),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(1))
 				Expect(pools[0].Devices[0].ID.Device).To(Equal(unique.Make("gpu-0")))
@@ -1132,7 +1175,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(1))
 				Expect(pools[0].NonTargetingDevices).To(BeEmpty())
@@ -1167,7 +1210,7 @@ var _ = Describe("Pool Gathering", func() {
 						},
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(1))
 				Expect(pools[0].NonTargetingDevices).To(HaveLen(2))
@@ -1201,7 +1244,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 3),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].NonTargetingDevices).To(HaveLen(1))
 				ntd := pools[0].NonTargetingDevices[0]
@@ -1233,7 +1276,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Slices).To(BeEmpty())
 				Expect(pools[0].Devices).To(BeEmpty())
@@ -1246,7 +1289,7 @@ var _ = Describe("Pool Gathering", func() {
 
 	Describe("FilterPools", func() {
 		It("should return an empty list when no pools are provided", func() {
-			filtered := dynamicresources.FilterPools(nil, reqs)
+			filtered := dynamicresources.FilterPools(nil, reqs, "")
 			Expect(filtered).To(BeEmpty())
 		})
 
@@ -1257,13 +1300,13 @@ var _ = Describe("Pool Gathering", func() {
 					withAPIDevices("gpu-0"),
 				),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(1))
 
 			tightened := scheduling.NewRequirements(
 				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 			)
-			filtered := dynamicresources.FilterPools(pools, tightened)
+			filtered := dynamicresources.FilterPools(pools, tightened, "")
 			Expect(filtered).To(HaveLen(1))
 		})
 
@@ -1274,13 +1317,13 @@ var _ = Describe("Pool Gathering", func() {
 					withAPIDevices("gpu-0"),
 				),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(1))
 
 			tightened := scheduling.NewRequirements(
 				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2b"),
 			)
-			filtered := dynamicresources.FilterPools(pools, tightened)
+			filtered := dynamicresources.FilterPools(pools, tightened, "")
 			Expect(filtered).To(BeEmpty())
 		})
 
@@ -1291,7 +1334,7 @@ var _ = Describe("Pool Gathering", func() {
 				},
 			}
 			Expect(func() {
-				dynamicresources.FilterPools([]*dynamicresources.Pool{pool}, reqs)
+				dynamicresources.FilterPools([]*dynamicresources.Pool{pool}, reqs, "")
 			}).To(PanicWith("potential slices must not be passed to pool gathering or filtering"))
 		})
 
@@ -1299,12 +1342,12 @@ var _ = Describe("Pool Gathering", func() {
 			slices := []dynamicresources.ResourceSlice{
 				makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(), withAPIDevices("gpu-0")),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 
 			tightened := scheduling.NewRequirements(
 				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "ap-southeast-1a"),
 			)
-			filtered := dynamicresources.FilterPools(pools, tightened)
+			filtered := dynamicresources.FilterPools(pools, tightened, "")
 			Expect(filtered).To(HaveLen(1))
 		})
 
@@ -1319,13 +1362,13 @@ var _ = Describe("Pool Gathering", func() {
 					withAPIDevices("nic-0"),
 				),
 			}
-			pools := dynamicresources.GatherPools(slices, reqs)
+			pools := dynamicresources.GatherPools(slices, reqs, "")
 			Expect(pools).To(HaveLen(2))
 
 			tightened := scheduling.NewRequirements(
 				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 			)
-			filtered := dynamicresources.FilterPools(pools, tightened)
+			filtered := dynamicresources.FilterPools(pools, tightened, "")
 			Expect(filtered).To(HaveLen(1))
 			Expect(filtered[0].Key.Pool).To(Equal(unique.Make("pool-a")))
 		})
@@ -1345,7 +1388,7 @@ var _ = Describe("Pool Gathering", func() {
 					withAPIDevices("gpu-1"),
 				),
 			}
-			pools := dynamicresources.GatherPools(slices, broad)
+			pools := dynamicresources.GatherPools(slices, broad, "")
 			Expect(pools).To(HaveLen(1))
 			Expect(pools[0].Slices).To(HaveLen(2))
 			Expect(pools[0].Devices).To(HaveLen(2))
@@ -1354,7 +1397,7 @@ var _ = Describe("Pool Gathering", func() {
 			tightened := scheduling.NewRequirements(
 				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 			)
-			filtered := dynamicresources.FilterPools(pools, tightened)
+			filtered := dynamicresources.FilterPools(pools, tightened, "")
 			Expect(filtered).To(HaveLen(1))
 			Expect(filtered[0].Slices).To(HaveLen(1))
 			Expect(filtered[0].Devices).To(HaveLen(1))
@@ -1367,7 +1410,7 @@ var _ = Describe("Pool Gathering", func() {
 					makeAPISlice("s1", "gpu.example.com", "pool-a", withAPIDevices("gpu-0")),
 				},
 			}
-			filtered := dynamicresources.FilterPools([]*dynamicresources.Pool{pool}, reqs)
+			filtered := dynamicresources.FilterPools([]*dynamicresources.Pool{pool}, reqs, "")
 			Expect(filtered).To(BeEmpty())
 		})
 
@@ -1390,10 +1433,10 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 
-				filtered := dynamicresources.FilterPools(pools, reqs)
+				filtered := dynamicresources.FilterPools(pools, reqs, "")
 				Expect(filtered).To(HaveLen(1))
 				Expect(filtered[0].CounterSets).To(HaveKey("budget"))
 				Expect(filtered[0].CounterSets["budget"]["memory"].Value.Equal(resource.MustParse("80Gi"))).To(BeTrue())
@@ -1429,7 +1472,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 3),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, broad)
+				pools := dynamicresources.GatherPools(slices, broad, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(2))
 				Expect(pools[0].NonTargetingDevices).To(BeEmpty())
@@ -1438,7 +1481,7 @@ var _ = Describe("Pool Gathering", func() {
 				tightened := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 				)
-				filtered := dynamicresources.FilterPools(pools, tightened)
+				filtered := dynamicresources.FilterPools(pools, tightened, "")
 				Expect(filtered).To(HaveLen(1))
 				Expect(filtered[0].Devices).To(HaveLen(1))
 				Expect(filtered[0].Devices[0].ID.Device).To(Equal(unique.Make("gpu-0")))
@@ -1462,13 +1505,13 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, broad)
+				pools := dynamicresources.GatherPools(slices, broad, "")
 				Expect(pools).To(HaveLen(1))
 
 				tightened := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 				)
-				filtered := dynamicresources.FilterPools(pools, tightened)
+				filtered := dynamicresources.FilterPools(pools, tightened, "")
 				Expect(filtered).To(HaveLen(1))
 				Expect(filtered[0].Devices).To(HaveLen(1))
 				Expect(filtered[0].NonTargetingDevices).To(BeEmpty())
@@ -1514,7 +1557,7 @@ var _ = Describe("Pool Gathering", func() {
 					),
 				}
 				// Gather with broad requirements — eu-west-1a is non-matching, gpu-2 goes to NonTargeting
-				pools := dynamicresources.GatherPools(slices, broad)
+				pools := dynamicresources.GatherPools(slices, broad, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].NonTargetingDevices).To(HaveLen(1))
 				Expect(pools[0].NonTargetingDevices[0].ID.Device).To(Equal(unique.Make("gpu-2")))
@@ -1523,7 +1566,7 @@ var _ = Describe("Pool Gathering", func() {
 				tightened := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 				)
-				filtered := dynamicresources.FilterPools(pools, tightened)
+				filtered := dynamicresources.FilterPools(pools, tightened, "")
 				Expect(filtered).To(HaveLen(1))
 				Expect(filtered[0].Devices).To(HaveLen(1))
 				Expect(filtered[0].Devices[0].ID.Device).To(Equal(unique.Make("gpu-0")))
@@ -1554,14 +1597,14 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 
 				// Even with different zone requirements, the pool with AllNodes devices is retained
 				tightened := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "ap-southeast-1a"),
 				)
-				filtered := dynamicresources.FilterPools(pools, tightened)
+				filtered := dynamicresources.FilterPools(pools, tightened, "")
 				Expect(filtered).To(HaveLen(1))
 				Expect(filtered[0].CounterSets).To(HaveKey("budget"))
 			})
@@ -1580,12 +1623,12 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 3),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, reqs)
+				pools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Incomplete).To(BeTrue())
 				Expect(pools[0].Invalid).To(BeTrue())
 
-				filtered := dynamicresources.FilterPools(pools, reqs)
+				filtered := dynamicresources.FilterPools(pools, reqs, "")
 				Expect(filtered).To(HaveLen(1))
 				Expect(filtered[0].Incomplete).To(BeTrue())
 				Expect(filtered[0].Invalid).To(BeTrue())
@@ -1601,7 +1644,7 @@ var _ = Describe("Pool Gathering", func() {
 				broad := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a", "us-west-2b"),
 				)
-				pools := dynamicresources.GatherPools(slices, broad)
+				pools := dynamicresources.GatherPools(slices, broad, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Invalid).To(BeTrue())
 
@@ -1610,7 +1653,7 @@ var _ = Describe("Pool Gathering", func() {
 				tightened := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2b"),
 				)
-				filtered := dynamicresources.FilterPools(pools, tightened)
+				filtered := dynamicresources.FilterPools(pools, tightened, "")
 				Expect(filtered).To(HaveLen(1))
 				Expect(filtered[0].Invalid).To(BeTrue())
 				Expect(filtered[0].Devices).To(BeEmpty())
@@ -1658,7 +1701,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 4),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, broad)
+				pools := dynamicresources.GatherPools(slices, broad, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(2))
 				Expect(pools[0].NonTargetingDevices).To(HaveLen(1))
@@ -1668,7 +1711,7 @@ var _ = Describe("Pool Gathering", func() {
 				filter1 := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2a"),
 				)
-				filtered1 := dynamicresources.FilterPools(pools, filter1)
+				filtered1 := dynamicresources.FilterPools(pools, filter1, "")
 				Expect(filtered1).To(HaveLen(1))
 				Expect(filtered1[0].Devices).To(HaveLen(1))
 				Expect(filtered1[0].NonTargetingDevices).To(HaveLen(2))
@@ -1678,7 +1721,7 @@ var _ = Describe("Pool Gathering", func() {
 				filter2 := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2b"),
 				)
-				filtered2 := dynamicresources.FilterPools(pools, filter2)
+				filtered2 := dynamicresources.FilterPools(pools, filter2, "")
 				Expect(filtered2).To(HaveLen(1))
 				Expect(filtered2[0].Devices).To(HaveLen(1))
 				Expect(filtered2[0].Devices[0].ID.Device).To(Equal(unique.Make("gpu-1")))
@@ -1711,7 +1754,7 @@ var _ = Describe("Pool Gathering", func() {
 						withGeneration(1, 2),
 					),
 				}
-				pools := dynamicresources.GatherPools(slices, broad)
+				pools := dynamicresources.GatherPools(slices, broad, "")
 				Expect(pools).To(HaveLen(1))
 				Expect(pools[0].Devices).To(HaveLen(1))
 
@@ -1720,7 +1763,7 @@ var _ = Describe("Pool Gathering", func() {
 				tightened := scheduling.NewRequirements(
 					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-west-2b"),
 				)
-				filtered := dynamicresources.FilterPools(pools, tightened)
+				filtered := dynamicresources.FilterPools(pools, tightened, "")
 				Expect(filtered).To(HaveLen(1))
 				Expect(filtered[0].Slices).To(BeEmpty())
 				Expect(filtered[0].Devices).To(BeEmpty())

--- a/pkg/scheduling/dynamicresources/request_test.go
+++ b/pkg/scheduling/dynamicresources/request_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Request Validation", func() {
 			makeAPISlice("s1", "gpu.example.com", "pool-a", withAllNodes(),
 				withGeneration(1, 1), withAPIDevices("gpu-0", "gpu-1", "gpu-2")),
 		}
-		pools = dynamicresources.GatherPools(slices, reqs)
+		pools = dynamicresources.GatherPools(slices, reqs, "")
 	})
 
 	// makeTemplateDevices builds a map of instance type ID to template devices for use
@@ -675,7 +675,7 @@ var _ = Describe("Request Validation", func() {
 							}),
 						)),
 				}
-				gpuPools := dynamicresources.GatherPools(slices, reqs)
+				gpuPools := dynamicresources.GatherPools(slices, reqs, "")
 
 				claim := &resourcev1.ResourceClaim{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-claim"},
@@ -790,7 +790,7 @@ var _ = Describe("Request Validation", func() {
 							}),
 						)),
 				}
-				inClusterPools := dynamicresources.GatherPools(slices, reqs)
+				inClusterPools := dynamicresources.GatherPools(slices, reqs, "")
 
 				claim := &resourcev1.ResourceClaim{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-claim"},
@@ -858,7 +858,7 @@ var _ = Describe("Request Validation", func() {
 							}),
 						)),
 				}
-				inClusterPools := dynamicresources.GatherPools(slices, reqs)
+				inClusterPools := dynamicresources.GatherPools(slices, reqs, "")
 
 				claim := &resourcev1.ResourceClaim{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-claim"},
@@ -898,7 +898,7 @@ var _ = Describe("Request Validation", func() {
 					makeAPISlice("s2", "nic.example.com", "pool-b", withAllNodes(), withGeneration(1, 1),
 						withAPIDevices("nic-0")),
 				}
-				multiPools := dynamicresources.GatherPools(slices, reqs)
+				multiPools := dynamicresources.GatherPools(slices, reqs, "")
 				Expect(multiPools).To(HaveLen(2))
 
 				claim := &resourcev1.ResourceClaim{
@@ -967,7 +967,7 @@ var _ = Describe("Request Validation", func() {
 							}),
 						)),
 				}
-				a100Pools := dynamicresources.GatherPools(slices, reqs)
+				a100Pools := dynamicresources.GatherPools(slices, reqs, "")
 
 				claim := &resourcev1.ResourceClaim{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-claim"},
@@ -1025,7 +1025,7 @@ var _ = Describe("Request Validation", func() {
 					makeAPISlice("s-big", "gpu.example.com", "pool-big", withAllNodes(), withGeneration(1, 1),
 						withAPIDevices(deviceNames...)),
 				}
-				bigPools := dynamicresources.GatherPools(slices, reqs)
+				bigPools := dynamicresources.GatherPools(slices, reqs, "")
 
 				claim := &resourcev1.ResourceClaim{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-claim"},
@@ -1091,7 +1091,7 @@ var _ = Describe("Request Validation", func() {
 					makeAPISlice("s-20", "gpu.example.com", "pool-20", withAllNodes(), withGeneration(1, 1),
 						withAPIDevices(deviceNames...)),
 				}
-				largePools := dynamicresources.GatherPools(slices, reqs)
+				largePools := dynamicresources.GatherPools(slices, reqs, "")
 
 				templateDevices := makeTemplateDevices(map[string]int{
 					"c5.large":  10, // 20 + 10 = 30 <= 32
@@ -1135,7 +1135,7 @@ var _ = Describe("Request Validation", func() {
 					makeAPISlice("s-15", "gpu.example.com", "pool-15", withAllNodes(), withGeneration(1, 1),
 						withAPIDevices(deviceNames...)),
 				}
-				mixedPools := dynamicresources.GatherPools(slices, reqs)
+				mixedPools := dynamicresources.GatherPools(slices, reqs, "")
 
 				templateDevices := makeTemplateDevices(map[string]int{
 					"c5.large":  5,  // 25 + 5 = 30 <= 32
@@ -1184,7 +1184,7 @@ var _ = Describe("Request Validation", func() {
 					makeAPISlice("s-30", "gpu.example.com", "pool-30", withAllNodes(), withGeneration(1, 1),
 						withAPIDevices(deviceNames...)),
 				}
-				largePools := dynamicresources.GatherPools(slices, reqs)
+				largePools := dynamicresources.GatherPools(slices, reqs, "")
 
 				templateDevices := makeTemplateDevices(map[string]int{
 					"c5.large":  5, // 30 + 5 = 35 > 32

--- a/pkg/scheduling/dynamicresources/types.go
+++ b/pkg/scheduling/dynamicresources/types.go
@@ -61,6 +61,10 @@ func (id *DeviceID) String() string {
 type NodeClaim interface {
 	// ID returns a unique identifier for this NodeClaim.
 	ID() NodeClaimID
+	// NodeName returns the name of the concrete node backing this NodeClaim, or "" for in-flight/new NodeClaims that
+	// don't yet have a node. Published ResourceSlices pinned to a node via spec.nodeName are only accessible from the
+	// existing node with this name.
+	NodeName() string
 	// NodePoolID returns the NodePool this NodeClaim belongs to.
 	NodePoolID() NodePoolID
 	// Requirements returns the current scheduling requirements.
@@ -95,6 +99,10 @@ type ResourceSlice interface {
 	//     topology requirements that constrain the NodeClaim. Potential devices are always
 	//     node-local and do not constrain topology.
 	Potential() bool
+	// NodeName returns the name of the node the slice's devices are local to when the slice pins itself to a single
+	// node via spec.nodeName, or "" otherwise. A node-name-pinned slice is accessible only from that exact node, so it
+	// can never satisfy an in-flight NodeClaim — only an existing node with the same name.
+	NodeName() string
 	// NodeSelector returns the node selector if the slice uses label-based node affinity, or nil.
 	NodeSelector() *corev1.NodeSelector
 	// AllNodes returns true if the slice's devices are accessible from all nodes.
@@ -160,6 +168,10 @@ func (s *apiServerSlice) Potential() bool {
 	return false
 }
 
+func (s *apiServerSlice) NodeName() string {
+	return lo.FromPtr(s.slice.Spec.NodeName)
+}
+
 func (s *apiServerSlice) NodeSelector() *corev1.NodeSelector {
 	return s.slice.Spec.NodeSelector
 }
@@ -207,6 +219,10 @@ func (s *templateSlice) Devices() []cloudprovider.Device {
 
 func (s *templateSlice) Potential() bool {
 	return true
+}
+
+func (s *templateSlice) NodeName() string {
+	return ""
 }
 
 func (s *templateSlice) NodeSelector() *corev1.NodeSelector {

--- a/pkg/test/dra.go
+++ b/pkg/test/dra.go
@@ -1,0 +1,198 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/imdario/mergo"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DeviceClass creates a test DeviceClass with defaults that can be overridden by overrides.
+// Overrides are applied in order, with a last write wins semantic.
+func DeviceClass(overrides ...resourcev1.DeviceClass) *resourcev1.DeviceClass {
+	override := resourcev1.DeviceClass{}
+	for _, opts := range overrides {
+		if err := mergo.Merge(&override, opts, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("failed to merge: %v", err))
+		}
+	}
+	if override.Name == "" {
+		override.Name = RandomName()
+	}
+	return &resourcev1.DeviceClass{
+		ObjectMeta: ObjectMeta(override.ObjectMeta),
+		Spec:       override.Spec,
+	}
+}
+
+// DeviceClassWithSelector creates a DeviceClass whose single CEL selector matches the given driver.
+func DeviceClassWithSelector(name, driver string) *resourcev1.DeviceClass {
+	return DeviceClass(resourcev1.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourcev1.DeviceClassSpec{
+			Selectors: []resourcev1.DeviceSelector{
+				{CEL: &resourcev1.CELDeviceSelector{Expression: fmt.Sprintf("device.driver == %q", driver)}},
+			},
+		},
+	})
+}
+
+// ResourceClaim creates a test ResourceClaim with defaults that can be overridden by overrides.
+// Overrides are applied in order, with a last write wins semantic.
+func ResourceClaim(overrides ...resourcev1.ResourceClaim) *resourcev1.ResourceClaim {
+	override := resourcev1.ResourceClaim{}
+	for _, opts := range overrides {
+		if err := mergo.Merge(&override, opts, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("failed to merge: %v", err))
+		}
+	}
+	if override.Name == "" {
+		override.Name = RandomName()
+	}
+	if override.Namespace == "" {
+		override.Namespace = "default"
+	}
+	return &resourcev1.ResourceClaim{
+		ObjectMeta: ObjectMeta(override.ObjectMeta),
+		Spec:       override.Spec,
+		Status:     override.Status,
+	}
+}
+
+// ResourceClaimTemplate creates a test ResourceClaimTemplate with defaults that can be overridden by overrides.
+// Overrides are applied in order, with a last write wins semantic.
+func ResourceClaimTemplate(overrides ...resourcev1.ResourceClaimTemplate) *resourcev1.ResourceClaimTemplate {
+	override := resourcev1.ResourceClaimTemplate{}
+	for _, opts := range overrides {
+		if err := mergo.Merge(&override, opts, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("failed to merge: %v", err))
+		}
+	}
+	if override.Name == "" {
+		override.Name = RandomName()
+	}
+	if override.Namespace == "" {
+		override.Namespace = "default"
+	}
+	return &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: ObjectMeta(override.ObjectMeta),
+		Spec:       override.Spec,
+	}
+}
+
+// ExactDeviceRequest builds a DeviceRequest for a fixed number of devices of the given class.
+func ExactDeviceRequest(name, className string, count int64) resourcev1.DeviceRequest {
+	return resourcev1.DeviceRequest{
+		Name: name,
+		Exactly: &resourcev1.ExactDeviceRequest{
+			DeviceClassName: className,
+			Count:           count,
+		},
+	}
+}
+
+// AllDeviceRequest builds a DeviceRequest in "All" allocation mode for the given class.
+func AllDeviceRequest(name, className string) resourcev1.DeviceRequest {
+	return resourcev1.DeviceRequest{
+		Name: name,
+		Exactly: &resourcev1.ExactDeviceRequest{
+			DeviceClassName: className,
+			AllocationMode:  resourcev1.DeviceAllocationModeAll,
+		},
+	}
+}
+
+// MatchAttributeConstraint builds a DeviceConstraint requiring all listed requests to share an attribute value.
+// If requests is empty, the constraint applies to all requests in the claim.
+func MatchAttributeConstraint(attribute string, requests ...string) resourcev1.DeviceConstraint {
+	return resourcev1.DeviceConstraint{
+		Requests:       requests,
+		MatchAttribute: lo.ToPtr(resourcev1.FullyQualifiedName(attribute)),
+	}
+}
+
+// ResourceClaimForRequests builds a ResourceClaim in the default namespace containing the given device requests.
+func ResourceClaimForRequests(name string, requests ...resourcev1.DeviceRequest) *resourcev1.ResourceClaim {
+	return ResourceClaim(resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{Requests: requests},
+		},
+	})
+}
+
+// ResourceSlice creates a test ResourceSlice with defaults that can be overridden by overrides.
+// Overrides are applied in order, with a last write wins semantic. This is intended for cluster-wide
+// or non-node-local slices that the test manages directly; node-local slices for provisioned nodes are
+// created automatically by ExpectProvisioned.
+func ResourceSlice(overrides ...resourcev1.ResourceSlice) *resourcev1.ResourceSlice {
+	override := resourcev1.ResourceSlice{}
+	for _, opts := range overrides {
+		if err := mergo.Merge(&override, opts, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("failed to merge: %v", err))
+		}
+	}
+	if override.Name == "" {
+		override.Name = RandomName()
+	}
+	if override.Spec.Pool.Name == "" {
+		override.Spec.Pool.Name = override.Name
+	}
+	if override.Spec.Pool.ResourceSliceCount == 0 {
+		override.Spec.Pool.ResourceSliceCount = 1
+	}
+	if override.Spec.Pool.Generation == 0 {
+		override.Spec.Pool.Generation = 1
+	}
+	// A slice must be node-local, cluster-wide, or use a node selector. Default to cluster-wide when unset so the
+	// slice is usable from any node.
+	if override.Spec.NodeName == nil && override.Spec.NodeSelector == nil && override.Spec.AllNodes == nil {
+		override.Spec.AllNodes = lo.ToPtr(true)
+	}
+	return &resourcev1.ResourceSlice{
+		ObjectMeta: ObjectMeta(override.ObjectMeta),
+		Spec:       override.Spec,
+	}
+}
+
+// Device builds a ResourceSlice device with the given name and optional attributes.
+func Device(name string, attributes map[resourcev1.QualifiedName]resourcev1.DeviceAttribute) resourcev1.Device {
+	return resourcev1.Device{
+		Name:       name,
+		Attributes: attributes,
+	}
+}
+
+// StringAttribute is a convenience for building a string-valued device attribute.
+func StringAttribute(value string) resourcev1.DeviceAttribute {
+	return resourcev1.DeviceAttribute{StringValue: lo.ToPtr(value)}
+}
+
+// PodResourceClaimReference builds a PodResourceClaim referencing an existing ResourceClaim by name.
+func PodResourceClaimReference(name, claimName string) corev1.PodResourceClaim {
+	return corev1.PodResourceClaim{Name: name, ResourceClaimName: lo.ToPtr(claimName)}
+}
+
+// PodResourceClaimTemplateReference builds a PodResourceClaim referencing a ResourceClaimTemplate by name.
+func PodResourceClaimTemplateReference(name, templateName string) corev1.PodResourceClaim {
+	return corev1.PodResourceClaim{Name: name, ResourceClaimTemplateName: lo.ToPtr(templateName)}
+}

--- a/pkg/test/dra.go
+++ b/pkg/test/dra.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -108,6 +109,17 @@ func ExactDeviceRequest(name, className string, count int64) resourcev1.DeviceRe
 			Count:           count,
 		},
 	}
+}
+
+// ExactDeviceRequestWithCapacity builds a DeviceRequest for a fixed number of devices of the given class that also
+// requests a slice of per-dimension capacity from each device (the consumable-capacity path). A nil or empty capacity
+// map is equivalent to ExactDeviceRequest.
+func ExactDeviceRequestWithCapacity(name, className string, count int64, capacity map[resourcev1.QualifiedName]resource.Quantity) resourcev1.DeviceRequest {
+	req := ExactDeviceRequest(name, className, count)
+	if len(capacity) > 0 {
+		req.Exactly.Capacity = &resourcev1.CapacityRequirements{Requests: capacity}
+	}
+	return req
 }
 
 // AllDeviceRequest builds a DeviceRequest in "All" allocation mode for the given class.

--- a/pkg/test/dra.go
+++ b/pkg/test/dra.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/imdario/mergo"
 	"github.com/samber/lo"
@@ -207,4 +208,164 @@ func PodResourceClaimReference(name, claimName string) corev1.PodResourceClaim {
 // PodResourceClaimTemplateReference builds a PodResourceClaim referencing a ResourceClaimTemplate by name.
 func PodResourceClaimTemplateReference(name, templateName string) corev1.PodResourceClaim {
 	return corev1.PodResourceClaim{Name: name, ResourceClaimTemplateName: lo.ToPtr(templateName)}
+}
+
+const (
+	// GPUDriver and NICDriver are the DRA driver names used by the shared DRA test fixtures.
+	GPUDriver = "gpu.example.com"
+	NICDriver = "nic.example.com"
+	// CapacityMemory is the consumable-capacity dimension used by the shared DRA test fixtures.
+	CapacityMemory resourcev1.QualifiedName = GPUDriver + "/memory"
+)
+
+// NodeLocalPoolName returns the auto-generated pool name for a node-local DRA driver's ResourceSlice, matching the
+// framework's <driver>/<node> convention so device allocation status reconciliation lines up.
+func NodeLocalPoolName(driverName, nodeName string) string {
+	return fmt.Sprintf("%s/%s", driverName, nodeName)
+}
+
+// SanitizeDriver renders a driver name safe for use in object names by replacing "." and "/" with "-".
+func SanitizeDriver(driver string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(driver, ".", "-"), "/", "-")
+}
+
+// CapacityRequest builds a single-dimension (CapacityMemory) capacity request map for the given quantity.
+func CapacityRequest(amount string) map[resourcev1.QualifiedName]resource.Quantity {
+	return map[resourcev1.QualifiedName]resource.Quantity{CapacityMemory: resource.MustParse(amount)}
+}
+
+// NodeLocalSlice builds a published in-cluster ResourceSlice owned by and pinned to the given node via spec.nodeName —
+// the form kubelet/DRA drivers use for node-local devices. Such a slice is accessible only from the existing node with
+// that name. The pool name follows the NodeLocalPoolName convention so device allocation status reconciliation lines up.
+func NodeLocalSlice(node *corev1.Node, driver string, deviceNames ...string) *resourcev1.ResourceSlice {
+	return ResourceSlice(resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%s", node.Name, SanitizeDriver(driver)),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       node.Name,
+				UID:        node.UID,
+			}},
+		},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver:   driver,
+			NodeName: lo.ToPtr(node.Name),
+			Pool:     resourcev1.ResourcePool{Name: NodeLocalPoolName(driver, node.Name), Generation: 1, ResourceSliceCount: 1},
+			Devices:  lo.Map(deviceNames, func(name string, _ int) resourcev1.Device { return resourcev1.Device{Name: name} }),
+		},
+	})
+}
+
+// ZonedSlice builds a published, cluster-managed ResourceSlice whose devices are constrained to a topology zone via a
+// NodeSelector. It is not owned by any node (cluster-managed), so it is always gathered, and its zone requirement is
+// propagated onto a NodeClaim that allocates from it.
+func ZonedSlice(name, driver, zone string, deviceNames ...string) *resourcev1.ResourceSlice {
+	return ResourceSlice(resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver: driver,
+			Pool:   resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
+			NodeSelector: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key:      corev1.LabelTopologyZone,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{zone},
+				}},
+			}}},
+			Devices: lo.Map(deviceNames, func(name string, _ int) resourcev1.Device { return resourcev1.Device{Name: name} }),
+		},
+	})
+}
+
+// ClusterWideSlice builds a published, cluster-wide (AllNodes) ResourceSlice. Its devices are accessible from any node
+// and the slice is always gathered (no node owner reference), isolating device-availability behavior from node state.
+func ClusterWideSlice(name, driver string, deviceNames ...string) *resourcev1.ResourceSlice {
+	return ResourceSlice(resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver:   driver,
+			AllNodes: lo.ToPtr(true),
+			Pool:     resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
+			Devices:  lo.Map(deviceNames, func(n string, _ int) resourcev1.Device { return resourcev1.Device{Name: n} }),
+		},
+	})
+}
+
+// SharedCapacitySlice builds a published, cluster-wide (AllNodes) ResourceSlice whose single device is
+// multi-allocatable and publishes the given total memory capacity. Used to seed an in-cluster shared device for the
+// consumable-capacity tests.
+func SharedCapacitySlice(name, driver, device, totalMemory string) *resourcev1.ResourceSlice {
+	return ResourceSlice(resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver:   driver,
+			AllNodes: lo.ToPtr(true),
+			Pool:     resourcev1.ResourcePool{Name: name, Generation: 1, ResourceSliceCount: 1},
+			Devices: []resourcev1.Device{{
+				Name:                     device,
+				AllowMultipleAllocations: lo.ToPtr(true),
+				Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+					CapacityMemory: {Value: resource.MustParse(totalMemory)},
+				},
+			}},
+		},
+	})
+}
+
+// AllocatedClusterWideClaim builds a ResourceClaim already allocated to a cluster-wide published device, reserved for
+// the given consumers. This seeds the deviceallocation controller's tracking so the allocator treats it as in-use.
+func AllocatedClusterWideClaim(name, pool, driver, device string, consumers ...resourcev1.ResourceClaimConsumerReference) *resourcev1.ResourceClaim {
+	return ResourceClaim(resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{ExactDeviceRequest("req", "gpu", 1)}},
+		},
+		Status: resourcev1.ResourceClaimStatus{
+			Allocation: &resourcev1.AllocationResult{
+				Devices: resourcev1.DeviceAllocationResult{
+					Results: []resourcev1.DeviceRequestAllocationResult{{
+						Request: "req",
+						Driver:  driver,
+						Pool:    pool,
+						Device:  device,
+					}},
+				},
+			},
+			ReservedFor: consumers,
+		},
+	})
+}
+
+// AllocatedSharedClaim builds a ResourceClaim already allocated to a shared (multi-allocatable) device, consuming the
+// given capacity and reserved for the given consumers. This seeds the deviceallocation controller so the allocator sees
+// the device's consumed capacity (and, via per-claim contributions, which pods hold which share).
+func AllocatedSharedClaim(name, pool, driver, device string, consumed map[resourcev1.QualifiedName]resource.Quantity, consumers ...resourcev1.ResourceClaimConsumerReference) *resourcev1.ResourceClaim {
+	return ResourceClaim(resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{
+				ExactDeviceRequestWithCapacity("req", "gpu", 1, consumed),
+			}},
+		},
+		Status: resourcev1.ResourceClaimStatus{
+			Allocation: &resourcev1.AllocationResult{
+				Devices: resourcev1.DeviceAllocationResult{
+					Results: []resourcev1.DeviceRequestAllocationResult{{
+						Request:          "req",
+						Driver:           driver,
+						Pool:             pool,
+						Device:           device,
+						ConsumedCapacity: consumed,
+					}},
+				},
+			},
+			ReservedFor: consumers,
+		},
+	})
+}
+
+// PodConsumer builds a ResourceClaimConsumerReference for a pod, for use as a ResourceClaim's reservedFor entry.
+func PodConsumer(pod *corev1.Pod) resourcev1.ResourceClaimConsumerReference {
+	return resourcev1.ResourceClaimConsumerReference{Resource: "pods", Name: pod.Name, UID: pod.UID}
 }

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -471,7 +471,7 @@ func expectResourceSlicesCreated(ctx context.Context, c client.Client, cp cloudp
 	}
 
 	for driver, templates := range templatesByDriver {
-		poolName := NodeLocalPoolName(driver, node.Name)
+		poolName := test.NodeLocalPoolName(driver, node.Name)
 		sliceCount := int64(len(templates))
 		for i, t := range templates {
 			devices := make([]resourcev1.Device, len(t.Devices))
@@ -519,10 +519,6 @@ func expectResourceSlicesCreated(ctx context.Context, c client.Client, cp cloudp
 			ExpectApplied(ctx, c, slice)
 		}
 	}
-}
-
-func NodeLocalPoolName(driverName, nodeName string) string {
-	return fmt.Sprintf("%s/%s", driverName, nodeName)
 }
 
 // ExpectResourceClaimsProcessed emulates the in-cluster ResourceClaim controller for a pod. For each of the pod's
@@ -674,7 +670,7 @@ func expectDRAClaimsAllocated(ctx context.Context, c client.Client, pod *corev1.
 		for i, device := range devices {
 			poolName := device.DeviceID.Pool.Value()
 			if device.DeviceID.Template {
-				poolName = NodeLocalPoolName(device.DeviceID.Driver.Value(), binding.Node.Name)
+				poolName = test.NodeLocalPoolName(device.DeviceID.Driver.Value(), binding.Node.Name)
 			}
 			results[i] = resourcev1.DeviceRequestAllocationResult{
 				Request: requestNames[i],

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -600,7 +600,7 @@ func ExpectDeviceAllocationReconciled(ctx context.Context, c client.Client, cont
 	}
 }
 
-// ExpectNodeClaimDRADrivers asserts the NodeClaim carries the karpenter.sh/dra-drivers annotation listing exactly the
+// ExpectNodeClaimDRADrivers asserts the NodeClaim carries the karpenter.sh/requested-dra-drivers annotation listing exactly the
 // expected driver names (order-independent).
 func ExpectNodeClaimDRADrivers(nc *v1.NodeClaim, drivers ...string) {
 	GinkgoHelper()

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unique"
 
 	opmetrics "github.com/awslabs/operatorpkg/metrics"
 	"github.com/awslabs/operatorpkg/singleton"
@@ -58,6 +59,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/apis/v1alpha1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/dynamicresources/deviceallocation"
 	"sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
 	"sigs.k8s.io/karpenter/pkg/controllers/provisioning/scheduling"
@@ -65,6 +67,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/controllers/state/informer"
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	pscheduling "sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
 	"sigs.k8s.io/karpenter/pkg/test"
 	testv1alpha1 "sigs.k8s.io/karpenter/pkg/test/v1alpha1"
 )
@@ -74,15 +77,18 @@ const (
 	RequestInterval           = 1 * time.Second
 )
 
-type Bindings map[*corev1.Pod]*Binding
+type ProvisioningResult struct {
+	Bindings                        map[*corev1.Pod]*Binding
+	ResourceClaimAllocationMetadata map[types.NamespacedName]*dynamicresources.ResourceClaimAllocationMetadata
+}
 
 type Binding struct {
 	NodeClaim *v1.NodeClaim
 	Node      *corev1.Node
 }
 
-func (b Bindings) Get(p *corev1.Pod) *Binding {
-	for k, v := range b {
+func (r ProvisioningResult) Get(p *corev1.Pod) *Binding {
+	for k, v := range r.Bindings {
 		if client.ObjectKeyFromObject(k) == client.ObjectKeyFromObject(p) {
 			return v
 		}
@@ -260,6 +266,7 @@ func ExpectCleanedUp(ctx context.Context, c client.Client) {
 		&v1.NodeClaim{},
 		&v1alpha1.NodeOverlay{},
 		&resourcev1.ResourceClaim{},
+		&resourcev1.ResourceClaimTemplate{},
 	} {
 		for _, namespace := range namespaces.Items {
 			wg.Add(1)
@@ -274,6 +281,17 @@ func ExpectCleanedUp(ctx context.Context, c client.Client) {
 					Expect(err).ToNot(HaveOccurred())
 				}
 			}(object, namespace.Name)
+		}
+	}
+	// Clean up cluster-scoped DRA objects. These aren't namespaced, so they're deleted once rather than per-namespace.
+	// Fail open on clusters where these types aren't served (e.g. K8s < 1.34).
+	for _, object := range []client.Object{
+		&resourcev1.DeviceClass{},
+		&resourcev1.ResourceSlice{},
+	} {
+		err := c.DeleteAllOf(ctx, object, &client.DeleteAllOfOptions{DeleteOptions: client.DeleteOptions{GracePeriodSeconds: new(int64(0))}})
+		if err != nil && !meta.IsNoMatchError(err) {
+			Expect(err).ToNot(HaveOccurred())
 		}
 	}
 	wg.Wait()
@@ -303,11 +321,11 @@ func ExpectFinalizersRemoved(ctx context.Context, c client.Client, objs ...clien
 	}
 }
 
-func ExpectProvisioned(ctx context.Context, c client.Client, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, pods ...*corev1.Pod) Bindings {
+func ExpectProvisioned(ctx context.Context, c client.Client, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, pods ...*corev1.Pod) ProvisioningResult {
 	GinkgoHelper()
-	bindings := ExpectProvisionedNoBinding(ctx, c, cluster, cloudProvider, provisioner, pods...)
+	result := ExpectProvisionedNoBinding(ctx, c, cluster, cloudProvider, provisioner, pods...)
 	podKeys := sets.NewString(lo.Map(pods, func(p *corev1.Pod, _ int) string { return client.ObjectKeyFromObject(p).String() })...)
-	for pod, binding := range bindings {
+	for pod, binding := range result.Bindings {
 		// Only bind the pods that are passed through
 		if podKeys.Has(client.ObjectKeyFromObject(pod).String()) {
 			// We have to manually bind the pod to the node when using a fakeClient by setting the value for pod.Spec.NodeName
@@ -320,37 +338,47 @@ func ExpectProvisioned(ctx context.Context, c client.Client, cluster *state.Clus
 				ExpectManualBinding(ctx, c, pod, binding.Node)
 			}
 			Expect(cluster.UpdatePod(ctx, pod)).To(Succeed()) // track pod bindings
+
+			if result.ResourceClaimAllocationMetadata != nil {
+				expectDRAClaimsAllocated(ctx, c, pod, binding, result.ResourceClaimAllocationMetadata)
+			}
 		}
 	}
-	return bindings
+	return result
 }
 
 //nolint:gocyclo
-func ExpectProvisionedNoBinding(ctx context.Context, c client.Client, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, pods ...*corev1.Pod) Bindings {
+func ExpectProvisionedNoBinding(ctx context.Context, c client.Client, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, pods ...*corev1.Pod) ProvisioningResult {
 	GinkgoHelper()
 	// Persist objects
 	for _, pod := range pods {
 		ExpectApplied(ctx, c, pod)
 	}
+	// envtest has no kube-controller-manager, so the controller that generates ResourceClaims from
+	// ResourceClaimTemplates and records them in pod status does not run. Emulate it so the provisioner's claim
+	// resolution sees resolvable claims.
+	for _, pod := range pods {
+		ExpectResourceClaimsProcessed(ctx, c, pod)
+	}
 	// TODO: Check the error on the provisioner scheduling round
 	results, err := provisioner.Schedule(ctx)
-	bindings := Bindings{}
+	result := ProvisioningResult{Bindings: map[*corev1.Pod]*Binding{}}
 	if err != nil {
 		log.Printf("error provisioning in test, %s", err)
-		return bindings
+		return result
 	}
 	for _, m := range results.NewNodeClaims {
 		// TODO: Check the error on the provisioner launch
 		nodeClaimName, err := provisioner.Create(ctx, m, provisioning.WithReason(metrics.ProvisionedReason))
 		if err != nil {
-			return bindings
+			return result
 		}
 		nodeClaim := &v1.NodeClaim{}
 		Expect(c.Get(ctx, types.NamespacedName{Name: nodeClaimName}, nodeClaim)).To(Succeed())
 		nodeClaim, node := ExpectNodeClaimDeployedAndStateUpdated(ctx, c, cluster, cloudProvider, nodeClaim)
 		if nodeClaim != nil && node != nil {
 			for _, pod := range m.Pods {
-				bindings[pod] = &Binding{
+				result.Bindings[pod] = &Binding{
 					NodeClaim: nodeClaim,
 					Node:      node,
 				}
@@ -359,15 +387,16 @@ func ExpectProvisionedNoBinding(ctx context.Context, c client.Client, cluster *s
 	}
 	for _, node := range results.ExistingNodes {
 		for _, pod := range node.Pods {
-			bindings[pod] = &Binding{
+			result.Bindings[pod] = &Binding{
 				Node: node.Node,
 			}
 			if node.NodeClaim != nil {
-				bindings[pod].NodeClaim = node.NodeClaim
+				result.Bindings[pod].NodeClaim = node.NodeClaim
 			}
 		}
 	}
-	return bindings
+	result.ResourceClaimAllocationMetadata = results.DRAClaimAllocationMetadata
+	return result
 }
 
 func ExpectProvisionedResults(ctx context.Context, c client.Client, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider, provisioner *provisioning.Provisioner, pods ...*corev1.Pod) scheduling.Results {
@@ -412,7 +441,301 @@ func ExpectNodeClaimDeployed(ctx context.Context, c client.Client, cloudProvider
 	node.Labels = lo.Assign(node.Labels, map[string]string{v1.NodeRegisteredLabelKey: "true"})
 	nc.Status.NodeName = node.Name
 	ExpectApplied(ctx, c, nc, node)
+	expectResourceSlicesCreated(ctx, c, cloudProvider, nc, node)
 	return nc, node, nil
+}
+
+func expectResourceSlicesCreated(ctx context.Context, c client.Client, cp cloudprovider.CloudProvider, nc *v1.NodeClaim, node *corev1.Node) {
+	GinkgoHelper()
+
+	instanceTypeName := nc.Labels[corev1.LabelInstanceTypeStable]
+	if instanceTypeName == "" {
+		return
+	}
+	np := &v1.NodePool{ObjectMeta: metav1.ObjectMeta{Name: nc.Labels[v1.NodePoolLabelKey]}}
+	instanceTypes, err := cp.GetInstanceTypes(ctx, np)
+	Expect(err).ToNot(HaveOccurred())
+	it, found := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool {
+		return it.Name == instanceTypeName
+	})
+	Expect(found).To(BeTrue(), "instance type %q not found in cloud provider", instanceTypeName)
+	if len(it.DynamicResources.ResourceSliceTemplates) == 0 {
+		return
+	}
+	Expect(node.UID).ToNot(BeEmpty(), "node %q has no UID, cannot create owner reference", node.Name)
+
+	// Group templates by driver to set ResourceSliceCount correctly
+	templatesByDriver := map[string][]*cloudprovider.ResourceSliceTemplate{}
+	for _, t := range it.DynamicResources.ResourceSliceTemplates {
+		templatesByDriver[t.Driver.Value()] = append(templatesByDriver[t.Driver.Value()], t)
+	}
+
+	for driver, templates := range templatesByDriver {
+		poolName := NodeLocalPoolName(driver, node.Name)
+		sliceCount := int64(len(templates))
+		for i, t := range templates {
+			devices := make([]resourcev1.Device, len(t.Devices))
+			for j, d := range t.Devices {
+				devices[j] = resourcev1.Device{
+					Name:       d.Name.Value(),
+					Attributes: d.Attributes,
+					Capacity:   d.Capacity,
+				}
+			}
+
+			sliceName := fmt.Sprintf("%s-%s", node.Name, strings.ReplaceAll(strings.ReplaceAll(driver, ".", "-"), "/", "-"))
+			if sliceCount > 1 {
+				sliceName = fmt.Sprintf("%s-%d", sliceName, i)
+			}
+			slice := &resourcev1.ResourceSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: sliceName,
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "v1",
+						Kind:       "Node",
+						Name:       node.Name,
+						UID:        node.UID,
+					}},
+				},
+				Spec: resourcev1.ResourceSliceSpec{
+					Driver:   driver,
+					NodeName: &node.Name,
+					Pool: resourcev1.ResourcePool{
+						Name:               poolName,
+						Generation:         1,
+						ResourceSliceCount: sliceCount,
+					},
+					Devices:        devices,
+					SharedCounters: t.SharedCounters,
+				},
+			}
+			ExpectApplied(ctx, c, slice)
+		}
+	}
+}
+
+func NodeLocalPoolName(driverName, nodeName string) string {
+	return fmt.Sprintf("%s/%s", driverName, nodeName)
+}
+
+// ExpectResourceClaimsProcessed emulates the in-cluster ResourceClaim controller for a pod. For each of the pod's
+// ResourceClaim references it ensures pod.Status.ResourceClaimStatuses is populated:
+//   - A direct ResourceClaimName reference must already exist on the cluster; otherwise the expectation fails.
+//   - A ResourceClaimTemplateName reference causes a ResourceClaim to be generated from the named template (if it
+//     hasn't been already) and recorded in the pod status.
+//
+// This runs before provisioner.Schedule so the allocator's claim resolution can resolve every referenced claim.
+func ExpectResourceClaimsProcessed(ctx context.Context, c client.Client, pod *corev1.Pod) {
+	GinkgoHelper()
+	if len(pod.Spec.ResourceClaims) == 0 {
+		return
+	}
+	existingStatuses := sets.New(lo.Map(pod.Status.ResourceClaimStatuses, func(s corev1.PodResourceClaimStatus, _ int) string {
+		return s.Name
+	})...)
+	for i := range pod.Spec.ResourceClaims {
+		pc := &pod.Spec.ResourceClaims[i]
+		if existingStatuses.Has(pc.Name) {
+			continue
+		}
+		var claimName string
+		switch {
+		case pc.ResourceClaimName != nil:
+			// The claim must have been created by the test beforehand.
+			claim := &resourcev1.ResourceClaim{}
+			Expect(c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: *pc.ResourceClaimName}, claim)).To(Succeed(),
+				"referenced ResourceClaim %s/%s must exist before provisioning", pod.Namespace, *pc.ResourceClaimName)
+			claimName = *pc.ResourceClaimName
+		case pc.ResourceClaimTemplateName != nil:
+			template := &resourcev1.ResourceClaimTemplate{}
+			Expect(c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: *pc.ResourceClaimTemplateName}, template)).To(Succeed(),
+				"referenced ResourceClaimTemplate %s/%s must exist before provisioning", pod.Namespace, *pc.ResourceClaimTemplateName)
+			claimName = fmt.Sprintf("%s-%s", pod.Name, pc.Name)
+			claim := &resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   pod.Namespace,
+					Name:        claimName,
+					Labels:      template.Spec.Labels,
+					Annotations: template.Spec.Annotations,
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Name:       pod.Name,
+						UID:        pod.UID,
+					}},
+				},
+				Spec: template.Spec.Spec,
+			}
+			ExpectApplied(ctx, c, claim)
+		default:
+			Fail(fmt.Sprintf("pod %s/%s claim reference %q has neither ResourceClaimName nor ResourceClaimTemplateName", pod.Namespace, pod.Name, pc.Name))
+		}
+		pod.Status.ResourceClaimStatuses = append(pod.Status.ResourceClaimStatuses, corev1.PodResourceClaimStatus{
+			Name:              pc.Name,
+			ResourceClaimName: lo.ToPtr(claimName),
+		})
+	}
+	ExpectApplied(ctx, c, pod)
+}
+
+// ExpectDeviceAllocationReconciled reconciles the deviceallocation controller across every ResourceClaim currently on
+// the cluster. The first call triggers the controller's hydration (which otherwise blocks AllocatedDevices, and thus
+// the provisioner's DRA path); subsequent calls refresh the tracked allocation state to reflect claims allocated in a
+// prior provisioning run. envtest has no running controller manager, so tests must drive this explicitly before a
+// provisioning round that relies on the in-cluster allocated-device set.
+func ExpectDeviceAllocationReconciled(ctx context.Context, c client.Client, controller *deviceallocation.Controller) {
+	GinkgoHelper()
+	// The controller hydrates on its first Reconcile (guarded by sync.Once), which lists all claims and unblocks
+	// AllocatedDevices. Reconciling a non-existent key is sufficient to trigger hydration without double-closing the
+	// hydration channel, and is a no-op for tracking state when the claim is absent.
+	ExpectReconciled(ctx, controller, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "device-allocation-hydration-trigger"}})
+	// Reconcile every existing claim to pick up allocation-status changes committed by prior provisioning runs.
+	claimList := &resourcev1.ResourceClaimList{}
+	Expect(c.List(ctx, claimList)).To(Succeed())
+	for i := range claimList.Items {
+		ExpectReconciled(ctx, controller, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&claimList.Items[i])})
+	}
+}
+
+// ExpectNodeClaimDRADrivers asserts the NodeClaim carries the karpenter.sh/dra-drivers annotation listing exactly the
+// expected driver names (order-independent).
+func ExpectNodeClaimDRADrivers(nc *v1.NodeClaim, drivers ...string) {
+	GinkgoHelper()
+	annotation, ok := nc.Annotations[v1.DRADriversAnnotationKey]
+	Expect(ok).To(BeTrue(), "NodeClaim %s missing %s annotation", nc.Name, v1.DRADriversAnnotationKey)
+	Expect(strings.Split(annotation, ",")).To(ConsistOf(drivers))
+}
+
+// ExpectResourceClaimAllocated asserts a ResourceClaim has an allocation referencing the expected driver, and that
+// every allocated device belongs to that driver. Returns the pool-qualified device identities ("pool/device") for
+// further assertions. Pool qualification matters because node-local template devices reuse the same device name
+// across nodes — only the pool distinguishes them.
+func ExpectResourceClaimAllocated(ctx context.Context, c client.Client, namespace, name, driver string) []string {
+	GinkgoHelper()
+	claim := &resourcev1.ResourceClaim{}
+	Expect(c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, claim)).To(Succeed())
+	Expect(claim.Status.Allocation).ToNot(BeNil(), "ResourceClaim %s/%s has no allocation", namespace, name)
+	results := claim.Status.Allocation.Devices.Results
+	Expect(results).ToNot(BeEmpty())
+	devices := make([]string, 0, len(results))
+	for _, r := range results {
+		Expect(r.Driver).To(Equal(driver))
+		devices = append(devices, fmt.Sprintf("%s/%s", r.Pool, r.Device))
+	}
+	return devices
+}
+
+// ExpectInstanceTypeOptionNames returns the names of a NodeClaim's candidate instance type options.
+func ExpectInstanceTypeOptionNames(nc *scheduling.NodeClaim) []string {
+	GinkgoHelper()
+	return lo.Map(nc.InstanceTypeOptions, func(it *cloudprovider.InstanceType, _ int) string { return it.Name })
+}
+
+func expectDRAClaimsAllocated(ctx context.Context, c client.Client, pod *corev1.Pod, binding *Binding, claimMetadata map[types.NamespacedName]*dynamicresources.ResourceClaimAllocationMetadata) {
+	GinkgoHelper()
+
+	instanceTypeName := binding.Node.Labels[corev1.LabelInstanceTypeStable]
+	itID := unique.Make(instanceTypeName)
+
+	for i := range pod.Spec.ResourceClaims {
+		podClaim := &pod.Spec.ResourceClaims[i]
+		// Resolve the backing claim name the same way the allocator does: a direct ResourceClaimName, otherwise the
+		// generated name recorded in pod status (for ResourceClaimTemplate references). A reference with no generated
+		// claim is skipped — there is nothing to allocate.
+		claimName, ok := resolvedClaimName(pod, podClaim)
+		if !ok {
+			continue
+		}
+		key := types.NamespacedName{Namespace: pod.Namespace, Name: claimName}
+
+		claim := &resourcev1.ResourceClaim{}
+		Expect(c.Get(ctx, key, claim)).To(Succeed())
+		if claim.Status.Allocation != nil {
+			continue
+		}
+
+		meta, ok := claimMetadata[key]
+		Expect(ok).To(BeTrue(), "missing DRA allocation metadata for claim %s", key)
+		devices, ok := meta.Devices[itID]
+		Expect(ok).To(BeTrue(), "no device allocation for instance type %q in claim %s", instanceTypeName, key)
+
+		// The API server requires each DeviceRequestAllocationResult.Request to name a real request in the claim. The
+		// allocator metadata only carries the ordered devices, not their owning request, but the allocator allocates
+		// requests in spec order, so we reconstruct the request name by consuming each request's device count in order.
+		requestNames := requestNamesForDevices(claim, len(devices))
+		results := make([]resourcev1.DeviceRequestAllocationResult, len(devices))
+		for i, device := range devices {
+			poolName := device.DeviceID.Pool.Value()
+			if device.DeviceID.Template {
+				poolName = NodeLocalPoolName(device.DeviceID.Driver.Value(), binding.Node.Name)
+			}
+			results[i] = resourcev1.DeviceRequestAllocationResult{
+				Request: requestNames[i],
+				Driver:  device.DeviceID.Driver.Value(),
+				Pool:    poolName,
+				Device:  device.DeviceID.Device.Value(),
+			}
+		}
+
+		claim.Status.Allocation = &resourcev1.AllocationResult{
+			Devices: resourcev1.DeviceAllocationResult{
+				Results: results,
+			},
+		}
+		ExpectApplied(ctx, c, claim)
+	}
+}
+
+// resolvedClaimName returns the name of the ResourceClaim backing a pod's claim reference: a direct ResourceClaimName,
+// otherwise the generated name recorded in pod.Status.ResourceClaimStatuses for a ResourceClaimTemplate reference. The
+// second return is false when no claim was generated for the reference. This mirrors the allocator's own resolution so
+// the test framework allocates the same claims the allocator did.
+func resolvedClaimName(pod *corev1.Pod, pc *corev1.PodResourceClaim) (string, bool) {
+	if pc.ResourceClaimName != nil {
+		return *pc.ResourceClaimName, true
+	}
+	for i := range pod.Status.ResourceClaimStatuses {
+		status := &pod.Status.ResourceClaimStatuses[i]
+		if status.Name == pc.Name {
+			if status.ResourceClaimName == nil {
+				return "", false
+			}
+			return *status.ResourceClaimName, true
+		}
+	}
+	return "", false
+}
+
+// requestNamesForDevices maps each of the deviceCount allocated devices (in allocation order) to the name of the claim
+// request that owns it. Requests are consumed in spec order: an ExactCount request claims its Count devices; an All
+// request (and any leftover devices) claim the remainder. This mirrors the allocator's request-ordered DFS so the
+// reconstructed request names are valid for API server validation.
+// TODO: Consider storing the associated request in ResourceClaimAllocationMetadata to avoid reverse engineering the
+// order. This isn't currently done since it would only be useful for integration tests.
+func requestNamesForDevices(claim *resourcev1.ResourceClaim, deviceCount int) []string {
+	names := make([]string, 0, deviceCount)
+	for _, req := range claim.Spec.Devices.Requests {
+		if len(names) >= deviceCount {
+			break
+		}
+		count := 1
+		if req.Exactly != nil {
+			switch {
+			case req.Exactly.AllocationMode == resourcev1.DeviceAllocationModeAll:
+				count = deviceCount - len(names) // claim all remaining devices
+			case req.Exactly.Count > 0:
+				count = int(req.Exactly.Count)
+			}
+		}
+		for i := 0; i < count && len(names) < deviceCount; i++ {
+			names = append(names, req.Name)
+		}
+	}
+	// Fallback: if requests didn't account for every device (shouldn't happen), pad with the last request name.
+	for len(names) < deviceCount && len(claim.Spec.Devices.Requests) > 0 {
+		names = append(names, claim.Spec.Devices.Requests[len(claim.Spec.Devices.Requests)-1].Name)
+	}
+	return names
 }
 
 func ExpectNodeClaimDeployedAndStateUpdated(ctx context.Context, c client.Client, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider, nc *v1.NodeClaim) (*v1.NodeClaim, *corev1.Node) {

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -476,11 +476,18 @@ func expectResourceSlicesCreated(ctx context.Context, c client.Client, cp cloudp
 		for i, t := range templates {
 			devices := make([]resourcev1.Device, len(t.Devices))
 			for j, d := range t.Devices {
-				devices[j] = resourcev1.Device{
-					Name:       d.Name.Value(),
-					Attributes: d.Attributes,
-					Capacity:   d.Capacity,
+				device := resourcev1.Device{
+					Name:             d.Name.Value(),
+					Attributes:       d.Attributes,
+					Capacity:         d.Capacity,
+					ConsumesCounters: d.ConsumesCounters,
 				}
+				// Only set AllowMultipleAllocations when true; leaving it nil for exclusive devices preserves the
+				// pre-capacity publish behavior (and a capacity RequestPolicy requires it to be true).
+				if d.AllowMultipleAllocations {
+					device.AllowMultipleAllocations = lo.ToPtr(true)
+				}
+				devices[j] = device
 			}
 
 			sliceName := fmt.Sprintf("%s-%s", node.Name, strings.ReplaceAll(strings.ReplaceAll(driver, ".", "-"), "/", "-"))

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -25,6 +25,7 @@ import (
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -106,6 +107,40 @@ func NodeEventHandler(c client.Client, cloudProvider cloudprovider.CloudProvider
 		// Because we get so many NodeClaims from this response, we are not DeepCopying the cached data here
 		// DO NOT MUTATE NodeClaims in this function as this will affect the underlying cached NodeClaim
 		ncs, err := ListManaged(ctx, c, cloudProvider, ForProviderID(o.(*corev1.Node).Spec.ProviderID), client.UnsafeDisableDeepCopy)
+		if err != nil {
+			return nil
+		}
+		return lo.Map(ncs, func(nc *v1.NodeClaim, _ int) reconcile.Request {
+			return reconcile.Request{NamespacedName: client.ObjectKeyFromObject(nc)}
+		})
+	})
+}
+
+// ResourceSliceEventHandler is a watcher on resourcev1.ResourceSlice that maps a slice to the NodeClaim(s) backing the
+// node the slice is local to (via spec.nodeName or a Node owner reference) and enqueues reconcile.Requests for them.
+// It lets the lifecycle controller re-evaluate initialization when a DRA driver publishes its slices.
+func ResourceSliceEventHandler(c client.Client, cloudProvider cloudprovider.CloudProvider) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		slice := o.(*resourcev1.ResourceSlice)
+		nodeName := lo.FromPtr(slice.Spec.NodeName)
+		if nodeName == "" {
+			for _, ref := range slice.OwnerReferences {
+				if ref.Kind == "Node" {
+					nodeName = ref.Name
+					break
+				}
+			}
+		}
+		if nodeName == "" {
+			return nil
+		}
+		node := &corev1.Node{}
+		if err := c.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+			return nil
+		}
+		// Because we get so many NodeClaims from this response, we are not DeepCopying the cached data here
+		// DO NOT MUTATE NodeClaims in this function as this will affect the underlying cached NodeClaim
+		ncs, err := ListManaged(ctx, c, cloudProvider, ForProviderID(node.Spec.ProviderID), client.UnsafeDisableDeepCopy)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Integrates DRA into Karpenter's core functionality: provisioning, disruption, and nodeclaim lifecycle. Support is gated by the IgnoreDRARequests CLI flag and is disabled by default. As a follow-up, we'll want to consider breaking out individual features into gates to maximize k8s distribution compatibility or minimally use runtime gates based on the k8s version.

**How was this change tested?**

`make presubmit` - additional integration testing and unit testing is included for all integration points.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
